### PR TITLE
Minor fixes: `sqrt()` and `!=`

### DIFF
--- a/mimium-lang/src/compiler/mirgen.rs
+++ b/mimium-lang/src/compiler/mirgen.rs
@@ -74,6 +74,7 @@ impl Context {
             (intrinsics::DIV, 2) => Instruction::DivF(args[0].clone(), args[1].clone()),
             (intrinsics::EXP, 2) => Instruction::PowF(args[0].clone(), args[1].clone()),
             (intrinsics::MODULO, 2) => Instruction::ModF(args[0].clone(), args[1].clone()),
+            (intrinsics::SQRT, 1) => Instruction::SqrtF(args[0].clone()),
             (intrinsics::ABS, 1) => Instruction::AbsF(args[0].clone()),
             (intrinsics::SIN, 1) => Instruction::SinF(args[0].clone()),
             (intrinsics::COS, 1) => Instruction::CosF(args[0].clone()),

--- a/mimium-lang/src/compiler/typing.rs
+++ b/mimium-lang/src/compiler/typing.rs
@@ -91,7 +91,7 @@ impl InferContext {
             intrinsics::GE,
             intrinsics::LE,
             intrinsics::EQ,
-            intrinsics::NEQ,
+            intrinsics::NE,
         ];
         let uniop_ty = function!(vec![numeric!()], numeric!());
         let uniop_names = vec![


### PR DESCRIPTION
Just happened to find these errors. I know this is under very active development, so please feel free to ignore!

`sqrt()`:

```
external function sqrt cannot be found
```


`!=`:
```
   │
 7 │   if (phasor(freq) != 0.0) {
   ·                    ─┬
   ·                     ╰── Variable ne not found in this scope
```