### PR TITLE
Fix an "index out of bounds" error

### DIFF
--- a/mimium-audiodriver/src/backends/cpal.rs
+++ b/mimium-audiodriver/src/backends/cpal.rs
@@ -108,8 +108,9 @@ impl NativeAudioReceiver {
         {
             match (h_ichannels, self.dsp_ichannels) {
                 (i1, i2) if i1 == i2 => {
-                    buf[0] = ic[0] as f64;
-                    buf[1] = ic[0] as f64;
+                    for i in 0..i1 {
+                        buf[i] = ic[i] as f64;
+                    }
                 }
                 (2, 1) => {
                     buf[0] = ic[0] as f64; //copy lch


### PR DESCRIPTION
This might be just because my setup is weird, but I see this error although the sound is generated as expected. I guess this is what you meant in this `match` branch to handle both `(1, 1)` and `(2, 2)`.

```
[*] input device: Microphone (USB Audio Device) buffer size:Fixed(2048)
[*] output device 1 - BenQ EW3280U (AMD High Definition Audio Device)buffer size:Fixed(2048)
[*] in:true out:true
thread 'cpal_wasapi_in' panicked at mimium-audiodriver\src\backends\cpal.rs:112:21:
index out of bounds: the len is 1 but the index is 1
```