### PR TITLE
implemented delay

### DIFF
--- a/mimium-cli/examples/fbdelay.mmm
+++ b/mimium-cli/examples/fbdelay.mmm
@@ -1,0 +1,20 @@
+let pi = 3.14159265359
+let sr = 44100.0
+fn phasor(freq){
+  (self + freq/sr)%1.0
+}
+fn osc(freq){
+  sin(phasor(freq)*pi*2.0)
+}
+fn amosc(freq,rate){
+  osc(freq)*(1.0- phasor(rate))
+}
+fn fbdelay(input,time,fb,mix){
+    input*mix + (1.0-mix) * delay(40001.0,(input+self*fb),time)
+}
+
+fn dsp(){
+    let sig = amosc(1000.0,1.0)
+    fbdelay(sig,40000.0,0.9,0.5)
+}
+

--- a/mimium-cli/examples/multiosc.mmm
+++ b/mimium-cli/examples/multiosc.mmm
@@ -7,19 +7,20 @@ fn osc(freq){
   sin(phasor(freq)*pi*2.0)
 }
 fn amosc(freq,rate){
-  osc(freq + osc(rate)*100.0)
+  osc(freq + osc(rate)*4000.0)
 }
 
 fn replicate(n:float,gen:()->(float,float)->float){
     if (n>0.0){
         let c = replicate(n - 1.0,gen)
         let g = gen()
-        |x,rate| {g(x,rate) + c(x+100.0,rate+0.5)}
+        |x,rate| {g(x,rate) + c(x+100.0,rate+0.1)}
     }else{
         |x,rate| { 0.0 }
     }
 }
-let mycounter = replicate(7.0,| |amosc);
+let n = 80.0
+let mycounter = replicate(n,| |amosc);
 fn dsp(){
-    mycounter(500.0,0.5)*0.1
+    mycounter(4000.0,0.5) / n
 }

--- a/mimium-lang/src/compiler/bytecodegen.rs
+++ b/mimium-lang/src/compiler/bytecodegen.rs
@@ -475,6 +475,19 @@ impl ByteCodeGenerator {
                 bytecodes_dst.push(VmInstruction::SetState(new));
                 Some(VmInstruction::Return(old, 1))
             }
+            mir::Instruction::Delay(max, src, time) => {
+                let s = self.vregister.find(src).unwrap();
+                let t = self.vregister.find(time).unwrap();
+
+                let dst = self.vregister.add_newvalue(&dst);
+                funcproto.delay_sizes.push(*max as u64);
+                Some(VmInstruction::Delay(dst, s, t))
+            }
+            mir::Instruction::Mem(src) => {
+                let s = self.vregister.find(src).unwrap();
+                let dst = self.vregister.add_newvalue(&dst);
+                Some(VmInstruction::Mem(dst, s))
+            }
             mir::Instruction::AddF(v1, v2) => self.emit_binop2(VmInstruction::AddF, &dst, v1, v2),
             mir::Instruction::SubF(v1, v2) => self.emit_binop2(VmInstruction::SubF, &dst, v1, v2),
             mir::Instruction::MulF(v1, v2) => self.emit_binop2(VmInstruction::MulF, &dst, v1, v2),

--- a/mimium-lang/src/compiler/intrinsics.rs
+++ b/mimium-lang/src/compiler/intrinsics.rs
@@ -22,3 +22,6 @@ pub(crate) const COS: &'static str = "cos";
 pub(crate) const SQRT: &'static str = "sqrt";
 pub(crate) const ABS: &'static str = "abs";
 pub(crate) const LOG: &'static str = "log";
+
+pub(crate) const DELAY: &'static str = "delay";
+pub(crate) const MEM: &'static str = "mem";

--- a/mimium-lang/src/compiler/typing.rs
+++ b/mimium-lang/src/compiler/typing.rs
@@ -95,6 +95,7 @@ impl InferContext {
         ];
         let uniop_ty = function!(vec![numeric!()], numeric!());
         let uniop_names = vec![
+            intrinsics::MEM,
             intrinsics::SIN,
             intrinsics::COS,
             intrinsics::ABS,
@@ -108,6 +109,10 @@ impl InferContext {
             .iter()
             .map(|n| (n.to_string(), uniop_ty.clone()))
             .collect_into(&mut binds);
+        binds.push((
+            intrinsics::DELAY.to_string(),
+            function!(vec![numeric!(), numeric!(), numeric!()], numeric!()),
+        ));
         env.add_bind(&mut binds);
     }
     fn register_builtin(env: &mut Environment<Type>) {

--- a/mimium-lang/src/mir.rs
+++ b/mimium-lang/src/mir.rs
@@ -71,6 +71,10 @@ pub enum Instruction {
     //value to update state
     ReturnFeed(VPtr),
 
+    Delay(u64,VPtr, VPtr),
+    Mem(VPtr),
+
+
     // Primitive Operations
     AddF(VPtr, VPtr),
     SubF(VPtr, VPtr),

--- a/mimium-lang/src/mir/print.rs
+++ b/mimium-lang/src/mir/print.rs
@@ -12,6 +12,7 @@ impl std::fmt::Display for Mir {
             if let Some(upper_i) = fun.upperfn_i {
                 let _ = write!(f, "upper:{upper_i}");
             }
+            let _ = write!(f," state_size: {}",fun.state_size);
             for (i, block) in fun.body.iter().enumerate() {
                 let _ = write!(f, "\n  block {i}\n");
                 for (v, insts) in block.0.iter() {
@@ -89,6 +90,8 @@ impl std::fmt::Display for Instruction {
             Instruction::Phi(t, e) => write!(f, "phi {t} {e}"),
             Instruction::Return(a) => write!(f, "ret {}", *a),
             Instruction::ReturnFeed(v) => write!(f, "retfeed {}", *v),
+            Instruction::Delay(max, a, b) => write!(f, "delay {max} {} {}", *a, *b),
+            Instruction::Mem(a) => write!(f, "mem {}", *a),
             Instruction::AddF(a, b) => write!(f, "addf {} {}", *a, *b),
             Instruction::SubF(a, b) => write!(f, "subf {} {}", *a, *b),
             Instruction::MulF(a, b) => write!(f, "mulf {} {}", *a, *b),

--- a/mimium-lang/src/runtime/vm/bytecode.rs
+++ b/mimium-lang/src/runtime/vm/bytecode.rs
@@ -39,6 +39,9 @@ pub enum Instruction {
     Return0,
     // value start position, Nrets
     Return(Reg, Reg),
+    //dst,src,time,idx 
+    Delay(Reg, Reg, Reg),
+    Mem(Reg, Reg),
 
     //jump label
     Jmp(Offset),
@@ -101,7 +104,12 @@ impl std::fmt::Display for Instruction {
             Instruction::Closure(dst, src) => {
                 write!(f, "{:<10} {} {}", "closure", dst, src)
             }
-
+            Instruction::Delay(dst, src, time) => {
+                write!(f, "{:<10} {} {} {}", "delay", dst, src, time)
+            }
+            Instruction::Mem(dst, src) => {
+                write!(f, "{:<10} {} {}", "mem", dst, src)
+            }
             Instruction::Return(iret, nret) => write!(f, "{:<10} {} {}", "ret", iret, nret),
             Instruction::GetUpValue(dst, srcup) => write!(f, "{:<10} {} {}", "getupv", dst, srcup),
             Instruction::SetUpValue(dstup, src) => write!(f, "{:<10} {} {}", "setupv", dstup, src),

--- a/mimium-lang/src/runtime/vm/program.rs
+++ b/mimium-lang/src/runtime/vm/program.rs
@@ -11,8 +11,8 @@ pub struct FuncProto {
     pub bytecodes: Vec<Instruction>,
     pub constants: Vec<RawVal>,
     // feedvalues are mapped in this vector
-    pub feedmap: Vec<usize>,
     pub state_size: u64,
+    pub delay_sizes:Vec<u64>,
 }
 impl FuncProto {
     pub fn new(nparam: usize, nret: usize) -> Self {
@@ -22,8 +22,8 @@ impl FuncProto {
             upindexes: vec![],
             bytecodes: vec![],
             constants: vec![],
-            feedmap: vec![],
             state_size: 0,
+            delay_sizes: vec![],
         }
     }
     pub fn add_new_constant(&mut self, cval: RawVal) -> usize {
@@ -42,8 +42,8 @@ impl From<&mir::Function> for FuncProto {
             upindexes: vec![],
             bytecodes: vec![],
             constants: vec![],
-            feedmap: vec![],
             state_size: value.state_size,
+            delay_sizes: vec![],
         }
     }
 }

--- a/mimium-lang/src/runtime/vm/ringbuffer.rs
+++ b/mimium-lang/src/runtime/vm/ringbuffer.rs
@@ -1,0 +1,47 @@
+use std::ptr::slice_from_raw_parts_mut;
+
+use super::RawVal;
+
+#[repr(C)]
+pub(super) struct Ringbuffer<'a> {
+    read_idx: &'a mut [u64],
+    write_idx: &'a mut [u64],
+    data: &'a mut [u64],
+}
+
+impl<'a> Ringbuffer<'a> {
+    pub fn new(head: *mut u64, size_in_samples: u64) -> Self {
+        let (read_idx, write_idx, data) = unsafe {
+            let read_idx = slice_from_raw_parts_mut(head, 1 as usize);
+            let write_ptr = head.offset(1);
+            let write_idx = slice_from_raw_parts_mut(write_ptr, 1 as usize);
+            let data_head = head.offset(2);
+            let data = slice_from_raw_parts_mut(data_head, size_in_samples as usize);
+            (
+                read_idx.as_mut().unwrap(),
+                write_idx.as_mut().unwrap(),
+                data.as_mut().unwrap(),
+            )
+        };
+
+        Self {
+            read_idx,
+            write_idx,
+            data,
+        }
+    }
+    pub fn process(&mut self, input: RawVal, time_raw: u64) -> RawVal {
+        let len = self.data.len() as u64;
+        let res = unsafe {
+            let time = std::mem::transmute::<u64, f64>(time_raw) as u64;
+            let read_idx = *self.read_idx.get_unchecked(0);
+            *self.write_idx.get_unchecked_mut(0) = (read_idx + time) % len;
+            let write_idx = *self.write_idx.get_unchecked(0);
+            let res = *self.data.get_unchecked(read_idx as usize);
+            *self.data.get_unchecked_mut(write_idx as usize) = input;
+            *self.read_idx.get_unchecked_mut(0) = (read_idx + 1) % len;
+            res
+        };
+        res
+    }
+}

--- a/mimium-lang/src/runtime/vm/test.rs
+++ b/mimium-lang/src/runtime/vm/test.rs
@@ -54,8 +54,8 @@ fn closuretest() {
         upindexes: vec![OpenUpValue(1), OpenUpValue(2)],
         bytecodes: inner_insts,
         constants: vec![], //no constants in the inner function
-        feedmap: vec![],
         state_size: 0,
+        delay_sizes:vec![]
     };
     let inner_insts2 = vec![
         // reg0:beg, reg1: inc
@@ -72,7 +72,7 @@ fn closuretest() {
         upindexes: vec![],
         bytecodes: inner_insts2,
         constants: vec![1u64, 2], // 1, position of inner in global table
-        feedmap: vec![],
+        delay_sizes:vec![],
         state_size: 0,
     };
     let main_inst = vec![
@@ -103,7 +103,7 @@ fn closuretest() {
         upindexes: vec![],
         bytecodes: main_inst,
         constants: vec![13u64, 7u64, 1, 0], //13,7, makecounter, print_f
-        feedmap: vec![],
+        delay_sizes:vec![],
         state_size: 0,
     };
     let global_fn_table = vec![
@@ -142,7 +142,7 @@ fn rust_closure_test() {
         upindexes: vec![],
         bytecodes: inner_insts,
         constants: vec![0u64, 4u64], //cls, int 4
-        feedmap: vec![],
+        delay_sizes:vec![],
         state_size: 0,
     };
     let fns = vec![main_f];

--- a/mimium-lang/tests/mmm/delay.mmm
+++ b/mimium-lang/tests/mmm/delay.mmm
@@ -1,0 +1,7 @@
+fn fbdelay(input,time,fb){
+    delay(300.0,input+self*fb,time)
+}
+
+fn dsp(){
+    fbdelay(1.0,100.0,0.8)+fbdelay(2.0,200.0,0.7)
+}

--- a/mimium-lang/tests/mmm/mem.mmm
+++ b/mimium-lang/tests/mmm/mem.mmm
@@ -1,0 +1,6 @@
+fn memtest(input){
+    mem(input)
+}
+fn dsp(){
+    memtest(1.0) + memtest(2.0)
+}


### PR DESCRIPTION
Implemented delay.

In this implementation, user need to specify maximum delay size as a first argument, and the argument need to be a number literal to evaluate at compilation time.
In the future spec, some constant folding using multi-stage computation will be introduced.
For example, delay with feedback can be written like this.

```rust
fn fbdelay(input,time,fb,mix){
    input*mix + (1.0-mix) * delay(40001.0,(input+self*fb),time)
}
```