### PR TITLE
Parse `^`

### DIFF
--- a/mimium-lang/src/compiler/bytecodegen.rs
+++ b/mimium-lang/src/compiler/bytecodegen.rs
@@ -493,6 +493,7 @@ impl ByteCodeGenerator {
             mir::Instruction::MulF(v1, v2) => self.emit_binop2(VmInstruction::MulF, &dst, v1, v2),
             mir::Instruction::DivF(v1, v2) => self.emit_binop2(VmInstruction::DivF, &dst, v1, v2),
             mir::Instruction::ModF(v1, v2) => self.emit_binop2(VmInstruction::ModF, &dst, v1, v2),
+            mir::Instruction::PowF(v1, v2) => self.emit_binop2(VmInstruction::PowF, &dst, v1, v2),
             mir::Instruction::SinF(v1) => self.emit_binop1(VmInstruction::SinF, &dst, v1),
             mir::Instruction::CosF(v1) => self.emit_binop1(VmInstruction::CosF, &dst, v1),
             mir::Instruction::AbsF(v1) => self.emit_binop1(VmInstruction::AbsF, &dst, v1),

--- a/mimium-lang/src/compiler/parser/lexer.rs
+++ b/mimium-lang/src/compiler/parser/lexer.rs
@@ -44,7 +44,7 @@ pub fn lexer() -> impl Parser<char, Vec<(Token, Span)>, Error = Simple<char>> {
         .map(Token::Str);
 
     // A parser for operators
-    let op = one_of("+-*/!=&|%><")
+    let op = one_of("+-*/!=&|%><^")
         .repeated()
         .at_least(1)
         .collect::<String>()


### PR DESCRIPTION
It seems the lexer has a definition for `^`, but it's missing from the regex pattern and bytecodegen.

https://github.com/tomoyanonymous/mimium-rs/blob/fadac989af8bc2a54a699080cbc5bf53fec223bc/mimium-lang/src/compiler/parser/lexer.rs#L66