### PR TITLE
chore: Rmove `then` token

### DIFF
--- a/mimium-lang/src/compiler/parser/lexer.rs
+++ b/mimium-lang/src/compiler/parser/lexer.rs
@@ -86,7 +86,6 @@ pub fn lexer() -> impl Parser<char, Vec<(Token, Span)>, Error = Simple<char>> {
         "@" => Token::At,
         "let" => Token::Let,
         "if" => Token::If,
-        "then" => Token::Then,
         "else" => Token::Else,
         // "true" => Token::Bool(true),
         // "false" => Token::Bool(false),

--- a/mimium-lang/src/compiler/parser/token.rs
+++ b/mimium-lang/src/compiler/parser/token.rs
@@ -74,7 +74,6 @@ pub enum Token {
     Arrow,    // ->
 
     If,
-    Then,
     Else,
 
     Return,
@@ -169,7 +168,6 @@ impl fmt::Display for Token {
             Token::Arrow => write!(f, "->"),
 
             Token::If => write!(f, "if"),
-            Token::Then => write!(f, "then"),
             Token::Else => write!(f, "else"),
 
             Token::Return => write!(f, "return"),


### PR DESCRIPTION
While `Expr` has `Then` to represent the then branch, it seems `Token` doesn't need `Then` because mimium's `if` statement doesn't have `then` keyword.

https://mimium.org/en/docs/users-guide/language-specification/grammar-rule/