### PR TITLE
Implement unary `-`

### DIFF
--- a/mimium-lang/src/ast_interpreter.rs
+++ b/mimium-lang/src/ast_interpreter.rs
@@ -83,13 +83,14 @@ impl Context {
     }
 }
 
-const EXTERN_ENV: [&str; 27] = [
-    "add", "sub", "mult", "div", "mod", "eq", "ne", "le", "lt", "ge", "gt", "atan2", "sin", "cos",
-    "not", "round", "floor", "ceil", "atan", "sqrt", "abs", "min", "max", "pow", "log", "print",
-    "println",
+const EXTERN_ENV: [&str; 28] = [
+    "neg", "add", "sub", "mult", "div", "mod", "eq", "ne", "le", "lt", "ge", "gt", "atan2", "sin",
+    "cos", "not", "round", "floor", "ceil", "atan", "sqrt", "abs", "min", "max", "pow", "log",
+    "print", "println",
 ];
 
 fn lookup_extern_env(name: &str) -> Option<&str> {
+    println!("{name}");
     let filtered = EXTERN_ENV
         .into_iter()
         .filter(|n| *n == name)

--- a/mimium-lang/src/ast_interpreter.rs
+++ b/mimium-lang/src/ast_interpreter.rs
@@ -90,7 +90,6 @@ const EXTERN_ENV: [&str; 28] = [
 ];
 
 fn lookup_extern_env(name: &str) -> Option<&str> {
-    println!("{name}");
     let filtered = EXTERN_ENV
         .into_iter()
         .filter(|n| *n == name)

--- a/mimium-lang/src/compiler/bytecodegen.rs
+++ b/mimium-lang/src/compiler/bytecodegen.rs
@@ -488,6 +488,7 @@ impl ByteCodeGenerator {
                 let dst = self.vregister.add_newvalue(&dst);
                 Some(VmInstruction::Mem(dst, s))
             }
+            mir::Instruction::NegF(v1) => self.emit_binop1(VmInstruction::NegF, &dst, v1),
             mir::Instruction::AddF(v1, v2) => self.emit_binop2(VmInstruction::AddF, &dst, v1, v2),
             mir::Instruction::SubF(v1, v2) => self.emit_binop2(VmInstruction::SubF, &dst, v1, v2),
             mir::Instruction::MulF(v1, v2) => self.emit_binop2(VmInstruction::MulF, &dst, v1, v2),

--- a/mimium-lang/src/compiler/intrinsics.rs
+++ b/mimium-lang/src/compiler/intrinsics.rs
@@ -1,3 +1,7 @@
+// unary
+pub(crate) const NEG: &'static str = "neg";
+
+// binary
 pub(crate) const ADD: &'static str = "add";
 pub(crate) const SUB: &'static str = "sub";
 pub(crate) const MULT: &'static str = "mult";
@@ -12,16 +16,17 @@ pub(crate) const MODULO: &'static str = "modulo";
 pub(crate) const EXP: &'static str = "exp";
 pub(crate) const AND: &'static str = "and";
 pub(crate) const OR: &'static str = "or";
-//arithmetics
+
+// arithmetics
 pub(crate) const SIN: &'static str = "sin";
 pub(crate) const COS: &'static str = "cos";
 // pub(crate) const TAN: &'static str = "tan";
 // pub(crate) const ATAN: &'static str = "atan";
 // pub(crate) const ATAN2: &'static str = "atan2";
-
 pub(crate) const SQRT: &'static str = "sqrt";
 pub(crate) const ABS: &'static str = "abs";
 pub(crate) const LOG: &'static str = "log";
 
+// other operations
 pub(crate) const DELAY: &'static str = "delay";
 pub(crate) const MEM: &'static str = "mem";

--- a/mimium-lang/src/compiler/mirgen.rs
+++ b/mimium-lang/src/compiler/mirgen.rs
@@ -113,6 +113,7 @@ impl Context {
         args: Vec<VPtr>,
     ) -> Result<Option<VPtr>, CompileError> {
         let inst = match (label.as_str(), args.len()) {
+            (intrinsics::NEG, 1) => Instruction::NegF(args[0].clone()),
             (intrinsics::ADD, 2) => Instruction::AddF(args[0].clone(), args[1].clone()),
             (intrinsics::SUB, 2) => Instruction::SubF(args[0].clone(), args[1].clone()),
             (intrinsics::MULT, 2) => Instruction::MulF(args[0].clone(), args[1].clone()),
@@ -275,12 +276,11 @@ impl Context {
             self.push_inst(Instruction::Uinteger(idx))
         };
         //insert pushstateoffset
-        let coffset =  self.get_ctxdata().state_offset;
+        let coffset = self.get_ctxdata().state_offset;
         if coffset > 0 {
-            self.get_current_basicblock().0.push((
-                Arc::new(Value::None),
-                Instruction::PushStateOffset(coffset),
-            ));
+            self.get_current_basicblock()
+                .0
+                .push((Arc::new(Value::None), Instruction::PushStateOffset(coffset)));
             self.get_ctxdata().push_sum += coffset;
         }
 

--- a/mimium-lang/src/compiler/parser.rs
+++ b/mimium-lang/src/compiler/parser.rs
@@ -117,6 +117,24 @@ fn expr_parser() -> impl Parser<Token, WithMeta<Expr>, Error = Simple<Token>> + 
                 .boxed()
                 .labelled("atoms");
 
+            let unary = select! { Token::Op(Op::Minus) => {} }
+                .repeated()
+                .then(atom)
+                .foldr(|_op, rhs| {
+                    let rhs_start = rhs.1.start;
+                    let op_start = rhs_start - 1;
+                    let span_end = rhs.1.end;
+                    let neg_op = Box::new(WithMeta(
+                        Expr::Var("neg".to_string(), None),
+                        op_start..rhs_start,
+                    ));
+                    WithMeta(
+                        Expr::Apply(neg_op, vec![WithMeta(rhs.0, rhs.1)]),
+                        op_start..span_end,
+                    )
+                })
+                .labelled("unary");
+
             let items = expr
                 .clone()
                 .separated_by(just(Token::Comma))
@@ -134,7 +152,7 @@ fn expr_parser() -> impl Parser<Token, WithMeta<Expr>, Error = Simple<Token>> + 
                     f.1.start..args.1.end,
                 )
             };
-            let apply = atom.then(parenitems).foldl(folder).labelled("apply");
+            let apply = unary.then(parenitems).foldl(folder).labelled("apply");
 
             let op_cls = |x: WithMeta<_>, y: WithMeta<_>, op: Op, opspan: Span| {
                 WithMeta(

--- a/mimium-lang/src/compiler/parser/lexer.rs
+++ b/mimium-lang/src/compiler/parser/lexer.rs
@@ -21,20 +21,10 @@ pub fn lexer() -> impl Parser<char, Vec<(Token, Span)>, Error = Simple<char>> {
     // A parser for numbers
     let int = text::int(10).map(|s: String| Token::Int(s.parse().unwrap()));
 
-    let float = just('-')
-        .or_not()
-        .then(
-            text::int(10)
-                .then(just('.'))
-                .then(text::digits(10).or_not()),
-        )
-        .map(|(optsign, ((s, c), opt_n))| {
-            let mut st = s + &c.to_string() + &opt_n.unwrap_or("".to_string());
-            if let Some(_) = optsign {
-                st = "-".to_string() + &st
-            };
-            Token::Float(st)
-        });
+    let float = text::int(10)
+        .then(just('.'))
+        .then(text::digits(10).or_not())
+        .map(|((s, _dot), opt_n)| Token::Float(format!("{}.{}", s, opt_n.unwrap_or_default())));
 
     // A parser for strings
     let str_ = just('"')

--- a/mimium-lang/src/compiler/typing.rs
+++ b/mimium-lang/src/compiler/typing.rs
@@ -95,6 +95,7 @@ impl InferContext {
         ];
         let uniop_ty = function!(vec![numeric!()], numeric!());
         let uniop_names = vec![
+            intrinsics::NEG,
             intrinsics::MEM,
             intrinsics::SIN,
             intrinsics::COS,

--- a/mimium-lang/src/runtime/builtin_fn.rs
+++ b/mimium-lang/src/runtime/builtin_fn.rs
@@ -20,6 +20,9 @@ fn b_to_i(b: bool) -> i64 {
 mod intrinsic {
     pub mod integer {
         use super::super::b_to_i;
+        pub fn neg(x: i64) -> i64 {
+            -x
+        }
         pub fn not(x: i64) -> i64 {
             if x <= 0 {
                 1
@@ -86,6 +89,9 @@ mod intrinsic {
         }
         pub fn cos(x: f64) -> f64 {
             x.cos()
+        }
+        pub fn neg(x: f64) -> f64 {
+            -x
         }
         pub fn not(x: f64) -> f64 {
             if x <= 0.0 {
@@ -222,8 +228,9 @@ macro_rules! f2_f {
     };
 }
 
-pub const BUILTIN_FNS: LazyCell<[BuiltinFn; 47]> = LazyCell::new(|| {
+pub const BUILTIN_FNS: LazyCell<[BuiltinFn; 49]> = LazyCell::new(|| {
     [
+        i_i!(neg),
         i_i!(not),
         i_i!(abs),
         i2_i!(add),
@@ -252,6 +259,7 @@ pub const BUILTIN_FNS: LazyCell<[BuiltinFn; 47]> = LazyCell::new(|| {
         ),
         f_f!(sin),
         f_f!(cos),
+        f_f!(neg),
         f_f!(not),
         f_f!(round),
         f_f!(floor),
@@ -302,6 +310,7 @@ pub fn eval_float1(name: &str, x: f64) -> Option<f64> {
     match name {
         "sin" => Some(x.sin()),
         "cos" => Some(x.cos()),
+        "neg" => Some(-x),
         "not" => Some(if x == 0.0 { 1.0 } else { 0.0 }),
         "round" => Some(x.round()),
         "floor" => Some(x.floor()),
@@ -337,6 +346,7 @@ pub fn eval_float2(name: &str, x: f64, y: f64) -> Option<f64> {
 
 pub fn eval_int1(name: &str, x: i64) -> Option<i64> {
     match name {
+        "neg" => Some(-x),
         "not" => Some(if x == 0 { 1 } else { 0 }),
         "abs" => Some(x.abs()),
         _ => None,

--- a/mimium-lang/tests/intergration_test.rs
+++ b/mimium-lang/tests/intergration_test.rs
@@ -36,8 +36,7 @@ fn simple_arithmetic() {
     run_simple_test("- -1.0", 1.0, 3);
     run_simple_test("-hoge", -2.0, 3);
     run_simple_test("-(-hoge)", 2.0, 3);
-    // TODO
-    // run_simple_test("-cos(0.0)", -1.0, 3);
+    run_simple_test("-cos(0.0)", -1.0, 3);
 
     // binary
     run_simple_test("hoge+1.0", 3.0, 3);

--- a/mimium-lang/tests/intergration_test.rs
+++ b/mimium-lang/tests/intergration_test.rs
@@ -33,13 +33,11 @@ fn simple_arithmetic() {
     // unary
     run_simple_test("1.0", 1.0, 3);
     run_simple_test("-1.0", -1.0, 3);
-    // TODO
-    // run_simple_test("-hoge", -2.0, 3);
+    run_simple_test("-hoge", -2.0, 3);
 
     // binary
     run_simple_test("hoge+1.0", 3.0, 3);
-    // TODO
-    // run_simple_test("hoge-1.0", 1.0, 3);
+    run_simple_test("hoge-1.0", 1.0, 3);
     run_simple_test("hoge*3.0", 6.0, 3);
     run_simple_test("hoge/2.0", 1.0, 3);
     run_simple_test("hoge^3.0", 8.0, 3);

--- a/mimium-lang/tests/intergration_test.rs
+++ b/mimium-lang/tests/intergration_test.rs
@@ -33,7 +33,11 @@ fn simple_arithmetic() {
     // unary
     run_simple_test("1.0", 1.0, 3);
     run_simple_test("-1.0", -1.0, 3);
+    run_simple_test("- -1.0", 1.0, 3);
     run_simple_test("-hoge", -2.0, 3);
+    run_simple_test("-(-hoge)", 2.0, 3);
+    // TODO
+    // run_simple_test("-cos(0.0)", -1.0, 3);
 
     // binary
     run_simple_test("hoge+1.0", 3.0, 3);


### PR DESCRIPTION
Currently, this code

```rs
fn dsp() {
    2.0-2.0
}
```

cannot be parsed.

```
Filename: \\?\C:\Users\Yutani\Documents\GitHub\mimium-rs\tmp.mmm
, ror: unexpected token something else, expected ^, ;,
, (, |, -, /, ", :, *, <, !, =, 0, ., +, }, [, ), %, ,, &, {, ], >
   ╭─[\\?\C:\Users\Yutani\Documents\GitHub\mimium-rs\tmp.mmm:2:3]
   │
 2 │     2.0-2.0
   ·   ┬
   ·   ╰── Unexpected token
───╯
Error: unexpected token while parsing apply, expected ||, linebreak, }, |>, >, -, <=, +, !=, /, ;, >=, &&, %, (, ==, <, *, ^
   ╭─[\\?\C:\Users\Yutani\Documents\GitHub\mimium-rs\tmp.mmm:2:8]
   │
 2 │     2.0-2.0
   ·        ──┬─
   ·          ╰─── Unexpected token -2.0
───╯
```

This is because there's no parser for unary operations. Currently, the lexer parses `-` as part of a float literal.

https://github.com/tomoyanonymous/mimium-rs/blob/ee0ed1a0cc5c3c8902bf95990d3209f2645e888d/mimium-lang/src/compiler/parser/lexer.rs#L24-L30

It might be a choice to require spaces before and after `-` to distinguish the binary op and the unary op. But, I think users expect this syntax is valid, so mimium anyway needs a unary parser.

```rs
-x
```