### PR TITLE
Add preliminary tuple support

### DIFF
--- a/mimium-lang/src/compiler/bytecodegen.rs
+++ b/mimium-lang/src/compiler/bytecodegen.rs
@@ -322,7 +322,11 @@ impl ByteCodeGenerator {
                             bytecodes_dst.unwrap_or_else(|| funcproto.bytecodes.as_mut());
                         let fadd = self.prepare_function(bytecodes_dst, dst, args);
                         bytecodes_dst.push(VmInstruction::MoveConst(dst, fi as ConstPos));
-                        bytecodes_dst.push(VmInstruction::CallExtFun(fadd as Reg, nargs, 1));
+                        bytecodes_dst.push(VmInstruction::CallExtFun(
+                            fadd as Reg,
+                            nargs,
+                            ty.size(),
+                        ));
                         for a in args {
                             //reset register for args
                             let _ = self.vregister.find(a);

--- a/mimium-lang/src/compiler/bytecodegen.rs
+++ b/mimium-lang/src/compiler/bytecodegen.rs
@@ -289,7 +289,7 @@ impl ByteCodeGenerator {
                 let idx = self.get_or_insert_global(v.clone());
                 Some(VmInstruction::SetGlobal(idx, s))
             }
-            mir::Instruction::Call(v, args) => {
+            mir::Instruction::Call(v, args, nret) => {
                 let nargs = args.len() as u8;
                 match v.as_ref() {
                     mir::Value::Register(_address) => {
@@ -299,15 +299,14 @@ impl ByteCodeGenerator {
                         let fadd = self.prepare_function(bytecodes_dst, faddress, args);
                         let dst = self.get_destination(dst);
 
-                        let nret = 1; // TODO
-                        bytecodes_dst.push(VmInstruction::Call(fadd, nargs, nret));
+                        bytecodes_dst.push(VmInstruction::Call(fadd, nargs, *nret));
                         for a in args {
                             //reset register for args
                             let _ = self.vregister.find(a);
                         }
                         (dst != fadd).then(|| VmInstruction::Move(dst, fadd))
                     }
-                    mir::Value::Function(_idx, _state_size) => {
+                    mir::Value::Function(_idx, _state_size, _nret) => {
                         unreachable!();
                     }
                     mir::Value::ExtFunction(label, ty) => {
@@ -352,7 +351,7 @@ impl ByteCodeGenerator {
                         }
                         (dst != fadd).then(|| VmInstruction::Move(dst, fadd))
                     }
-                    mir::Value::Function(_idx, _state_size) => {
+                    mir::Value::Function(_idx, _state_size, _nret) => {
                         unreachable!();
                     }
                     mir::Value::ExtFunction(_idx, _) => {

--- a/mimium-lang/src/compiler/mirgen.rs
+++ b/mimium-lang/src/compiler/mirgen.rs
@@ -205,7 +205,7 @@ impl Context {
         //do action
         let (fptr, ty) = action(self, c_idx)?;
 
-        // TODO
+        // TODO: ideally, type should be infered before the actual action
         let f = self.program.functions.get_mut(c_idx).unwrap();
         f.return_type = Some(ty.clone());
 
@@ -488,7 +488,7 @@ impl Context {
                                 let _ =
                                     ctx.push_inst(Instruction::Return(Arc::new(Value::None), nret));
                             }
-                            (Value::State(v), ty) => {
+                            (Value::State(v), _) => {
                                 let _ = ctx.push_inst(Instruction::ReturnFeed(v.clone(), nret));
                             }
                             (Value::Function(i, _, _), _) => {

--- a/mimium-lang/src/compiler/mirgen.rs
+++ b/mimium-lang/src/compiler/mirgen.rs
@@ -416,12 +416,15 @@ impl Context {
                         Value::Function(idx, statesize, nret) => {
                             self.emit_fncall(*idx as u64, *statesize, a_regs, nret.size())
                         }
-                        Value::ExtFunction(label, _ty) => {
+                        Value::ExtFunction(label, ty) => {
                             if let Some(res) = self.make_intrinsics(&label.0, a_regs.clone())? {
                                 res
                             } else {
-                                let nret = 1; // TODO
-                                self.push_inst(Instruction::Call(f.clone(), a_regs.clone(), nret))
+                                self.push_inst(Instruction::Call(
+                                    f.clone(),
+                                    a_regs.clone(),
+                                    ty.size(),
+                                ))
                             }
                         }
                         // Value::ExternalClosure(i) => todo!(),

--- a/mimium-lang/src/compiler/mirgen.rs
+++ b/mimium-lang/src/compiler/mirgen.rs
@@ -335,8 +335,16 @@ impl Context {
 
                 let mut types = Vec::with_capacity(len);
 
-                // prepare the sequence of registers before pushing other inst
-                // TODO: type needs to be inferred before evaluation.
+                // TODO: we have two unresolved problems.
+                //
+                // 1. Probably, Alloc should be able to prepare a sequence of
+                //    registers depending on the type. But, since currently
+                //    gen_new_register() is called in push_inst(), we need to
+                //    call Alloc multiple times to get multiple registers.
+                // 2. While the type can be known only after the expr is
+                //    evaluated, this instruction must be inserted before
+                //    eval_expr() to make sure there's a destination for each
+                //    value. Ideally, type should be inferred beforehand.
                 let dsts: Vec<_> = (0..len)
                     .map(|_| self.push_inst(Instruction::Alloc(Type::Unknown)))
                     .collect();
@@ -349,12 +357,11 @@ impl Context {
                     types.push(ty);
                 }
 
-                // validate if the types are all identical
-                // (TODO: allow different types in a tuple?)
-                let first_ty = &types[0];
-                if !types.iter().all(|x| x == first_ty) {
-                    todo!("Return error");
-                }
+                // TODO: validate if the types are all identical?
+                // let first_ty = &types[0];
+                // if !types.iter().all(|x| x == first_ty) {
+                //     todo!("Return error");
+                // }
 
                 // pass only the head of the tuple, and the length can be known
                 // from the type information.

--- a/mimium-lang/src/compiler/mirgen.rs
+++ b/mimium-lang/src/compiler/mirgen.rs
@@ -386,7 +386,7 @@ impl Context {
                     let res = match f.as_ref() {
                         Value::Global(v) => match v.as_ref() {
                             Value::Function(idx, statesize, nret) => {
-                                self.emit_fncall(*idx as u64, *statesize, a_regs, *nret)
+                                self.emit_fncall(*idx as u64, *statesize, a_regs, nret.size())
                             }
                             Value::Register(_) => {
                                 self.push_inst(Instruction::CallCls(v.clone(), a_regs.clone()))
@@ -414,7 +414,7 @@ impl Context {
                         }
 
                         Value::Function(idx, statesize, nret) => {
-                            self.emit_fncall(*idx as u64, *statesize, a_regs, *nret)
+                            self.emit_fncall(*idx as u64, *statesize, a_regs, nret.size())
                         }
                         Value::ExtFunction(label, _ty) => {
                             if let Some(res) = self.make_intrinsics(&label.0, a_regs.clone())? {
@@ -491,7 +491,7 @@ impl Context {
                             }
                         };
 
-                        let f = Arc::new(Value::Function(c_idx, state_size, nret));
+                        let f = Arc::new(Value::Function(c_idx, state_size, res_type.clone()));
                         Ok((f, res_type))
                     })?;
                 let child = self.program.functions.get_mut(c_idx).unwrap();

--- a/mimium-lang/src/compiler/parser.rs
+++ b/mimium-lang/src/compiler/parser.rs
@@ -25,9 +25,10 @@ fn type_parser() -> impl Parser<Token, Type, Error = Simple<Token>> + Clone {
             .separated_by(just(Token::Comma))
             .allow_trailing()
             .delimited_by(just(Token::ParenBegin), just(Token::ParenEnd))
-            .map(|e| Type::Tuple(e))
+            .map(Type::Tuple)
             .boxed()
             .labelled("Tuple");
+
         // let _struct_t = todo!();
         let atom = primitive.or(tuple);
         let func = atom
@@ -111,9 +112,6 @@ fn expr_parser() -> impl Parser<Token, WithMeta<Expr>, Error = Simple<Token>> + 
             let tuple = expr
                 .clone()
                 .separated_by(just(Token::Comma))
-                // TODO: for simplicity allow tuples with more than 2 elements
-                // (length-1 tuple is special in that the trailing comma is mandatory)
-                .at_least(2)
                 .allow_trailing()
                 .delimited_by(just(Token::ParenBegin), just(Token::ParenEnd))
                 .map_with_span(|e, s| WithMeta(Expr::Tuple(e), s))
@@ -389,7 +387,9 @@ fn func_parser() -> impl Parser<Token, WithMeta<Expr>, Error = Simple<Token>> + 
 }
 
 fn parser() -> impl Parser<Token, WithMeta<Expr>, Error = Simple<Token>> + Clone {
-    let ignored =comment_parser().or(just(Token::LineBreak).ignored()).or(just(Token::SemiColon).ignored());
+    let ignored = comment_parser()
+        .or(just(Token::LineBreak).ignored())
+        .or(just(Token::SemiColon).ignored());
     func_parser()
         .padded_by(ignored.repeated())
         .then_ignore(end())

--- a/mimium-lang/src/compiler/parser.rs
+++ b/mimium-lang/src/compiler/parser.rs
@@ -108,12 +108,24 @@ fn expr_parser() -> impl Parser<Token, WithMeta<Expr>, Error = Simple<Token>> + 
                 })
                 .labelled("macroexpand");
 
+            let tuple = expr
+                .clone()
+                .separated_by(just(Token::Comma))
+                // TODO: for simplicity allow tuples with more than 2 elements
+                // (length-1 tuple is special in that the trailing comma is mandatory)
+                .at_least(2)
+                .allow_trailing()
+                .delimited_by(just(Token::ParenBegin), just(Token::ParenEnd))
+                .map_with_span(|e, s| WithMeta(Expr::Tuple(e), s))
+                .labelled("tuple");
+
             let atom = val
                 .or(lambda)
                 .or(macro_expand)
                 .or(let_e)
                 .map_with_span(|e, s| WithMeta(e, s))
                 .or(parenexpr)
+                .or(tuple)
                 .boxed()
                 .labelled("atoms");
 

--- a/mimium-lang/src/compiler/parser/test.rs
+++ b/mimium-lang/src/compiler/parser/test.rs
@@ -241,6 +241,30 @@ fn test_macrodef() {
     );
     test_string!("macro hoge(input,gue){\n input\n}", ans);
 }
+
+#[test]
+fn test_tuple() {
+    let tuple_items = vec![
+        WithMeta(Expr::Literal(Literal::Float("1.0".to_string())), 1..4),
+        WithMeta(Expr::Literal(Literal::Float("2.0".to_string())), 6..9),
+    ];
+
+    let ans = WithMeta(Expr::Tuple(tuple_items.clone()), 0..10);
+    test_string!("(1.0, 2.0)", ans);
+
+    // with trailing comma
+    let ans = WithMeta(Expr::Tuple(tuple_items.clone()), 0..12);
+    test_string!("(1.0, 2.0, )", ans);
+
+    // trailing comma is mandatory for a single-element tuple
+    let ans = WithMeta(Expr::Tuple(vec![tuple_items[0].clone()]), 0..7);
+    test_string!("(1.0, )", ans);
+
+    // This is not a tuple
+    let ans = tuple_items[0].clone();
+    test_string!("(1.0)", ans);
+}
+
 #[test]
 #[should_panic]
 fn test_fail() {

--- a/mimium-lang/src/mir.rs
+++ b/mimium-lang/src/mir.rs
@@ -21,7 +21,7 @@ pub enum Value {
     Register(VReg),
     State(VPtr),
     // idx of the function in the program, size of internal state, and nret
-    Function(usize, u64, TypeSize),
+    Function(usize, u64, Type),
     ExtFunction(Label, Type),
     FixPoint(usize), //function id
     //internal state

--- a/mimium-lang/src/mir.rs
+++ b/mimium-lang/src/mir.rs
@@ -20,8 +20,8 @@ pub enum Value {
     // holds SSA index(position in infinite registers)
     Register(VReg),
     State(VPtr),
-    // idx of the function in the program, size of internal state
-    Function(usize, u64),
+    // idx of the function in the program, size of internal state, and nret
+    Function(usize, u64, TypeSize),
     ExtFunction(Label, Type),
     FixPoint(usize), //function id
     //internal state
@@ -45,7 +45,7 @@ pub enum Instruction {
     // Tuple(Vec<Value>),
     // Proj(Value, u64),
     // call function , arguments
-    Call(VPtr, Vec<VPtr>),
+    Call(VPtr, Vec<VPtr>, TypeSize),
     CallCls(VPtr, Vec<VPtr>),
     GetGlobal(VPtr),
     SetGlobal(VPtr, VPtr),

--- a/mimium-lang/src/mir.rs
+++ b/mimium-lang/src/mir.rs
@@ -1,5 +1,5 @@
 // Mid-level intermediate representation that is more like imperative form than hir.
-use crate::types::Type;
+use crate::types::{Type, TypeSize};
 use std::{cell::RefCell, rc::Rc, sync::Arc};
 
 pub mod print;
@@ -22,8 +22,8 @@ pub enum Value {
     State(VPtr),
     // idx of the function in the program, size of internal state
     Function(usize, u64),
-    ExtFunction(Label,Type),
-    FixPoint(usize),//function id
+    ExtFunction(Label, Type),
+    FixPoint(usize), //function id
     //internal state
     None, //??
 }
@@ -48,7 +48,7 @@ pub enum Instruction {
     Call(VPtr, Vec<VPtr>),
     CallCls(VPtr, Vec<VPtr>),
     GetGlobal(VPtr),
-    SetGlobal(VPtr,VPtr),
+    SetGlobal(VPtr, VPtr),
     // make closure with upindexes
     Closure(VPtr),
     //label to funcproto  and localvar offset?
@@ -67,13 +67,12 @@ pub enum Instruction {
     //merge
     Phi(VPtr, VPtr),
 
-    Return(VPtr),
+    Return(VPtr, TypeSize),
     //value to update state
-    ReturnFeed(VPtr),
+    ReturnFeed(VPtr, TypeSize),
 
-    Delay(u64,VPtr, VPtr),
+    Delay(u64, VPtr, VPtr),
     Mem(VPtr),
-
 
     // Primitive Operations
     AddF(VPtr, VPtr),
@@ -102,8 +101,8 @@ pub enum Instruction {
     LogI(VPtr, VPtr),
     // primitive Operations for bool
     Not(VPtr),
-    Eq(VPtr,VPtr),
-    Ne(VPtr,VPtr),
+    Eq(VPtr, VPtr),
+    Ne(VPtr, VPtr),
     Gt(VPtr, VPtr),
     Ge(VPtr, VPtr),
     Lt(VPtr, VPtr),
@@ -138,6 +137,7 @@ pub struct OpenUpValue(pub usize);
 pub struct Function {
     pub label: Label,
     pub args: Vec<Arc<Value>>,
+    pub return_type: Option<Type>, // TODO: None is the state when the type is not inferred yet.
     pub upindexes: Vec<Arc<Value>>,
     pub upperfn_i: Option<usize>,
     pub body: Vec<Block>,
@@ -148,6 +148,7 @@ impl Function {
         Self {
             label: Label(name.to_string()),
             args: args.to_vec(),
+            return_type: None,
             upindexes: vec![],
             upperfn_i,
             body: vec![Block::default()],

--- a/mimium-lang/src/mir.rs
+++ b/mimium-lang/src/mir.rs
@@ -20,7 +20,7 @@ pub enum Value {
     // holds SSA index(position in infinite registers)
     Register(VReg),
     State(VPtr),
-    // idx of the function in the program, size of internal state, and nret
+    // idx of the function in the program, size of internal state, return type
     Function(usize, u64, Type),
     ExtFunction(Label, Type),
     FixPoint(usize), //function id
@@ -44,7 +44,7 @@ pub enum Instruction {
     Store(VPtr, VPtr),
     // Tuple(Vec<Value>),
     // Proj(Value, u64),
-    // call function , arguments
+    // call function , arguments, nret
     Call(VPtr, Vec<VPtr>, TypeSize),
     CallCls(VPtr, Vec<VPtr>),
     GetGlobal(VPtr),

--- a/mimium-lang/src/mir/print.rs
+++ b/mimium-lang/src/mir/print.rs
@@ -12,7 +12,7 @@ impl std::fmt::Display for Mir {
             if let Some(upper_i) = fun.upperfn_i {
                 let _ = write!(f, "upper:{upper_i}");
             }
-            let _ = write!(f," state_size: {}",fun.state_size);
+            let _ = write!(f, " state_size: {}", fun.state_size);
             for (i, block) in fun.body.iter().enumerate() {
                 let _ = write!(f, "\n  block {i}\n");
                 for (v, insts) in block.0.iter() {
@@ -88,8 +88,8 @@ impl std::fmt::Display for Instruction {
             Instruction::JmpIf(cond, tbb, ebb) => write!(f, "jmpif {cond} {tbb} {ebb}"),
             Instruction::Jmp(bb) => write!(f, "jmp {bb}"),
             Instruction::Phi(t, e) => write!(f, "phi {t} {e}"),
-            Instruction::Return(a) => write!(f, "ret {}", *a),
-            Instruction::ReturnFeed(v) => write!(f, "retfeed {}", *v),
+            Instruction::Return(a, _nret) => write!(f, "ret {}", *a),
+            Instruction::ReturnFeed(v, _nret) => write!(f, "retfeed {}", *v),
             Instruction::Delay(max, a, b) => write!(f, "delay {max} {} {}", *a, *b),
             Instruction::Mem(a) => write!(f, "mem {}", *a),
             Instruction::AddF(a, b) => write!(f, "addf {} {}", *a, *b),

--- a/mimium-lang/src/mir/print.rs
+++ b/mimium-lang/src/mir/print.rs
@@ -46,7 +46,7 @@ impl std::fmt::Display for Value {
             Value::Global(gv) => write!(f, "global({})", *gv),
             Value::Argument(_, v) => write!(f, "{}", v.0),
             Value::Register(r) => write!(f, "reg({r})"),
-            Value::Function(id, _statesize) => write!(f, "function {id}"),
+            Value::Function(id, _statesize, nret) => write!(f, "function {id} (nret: {nret})"),
             Value::ExtFunction(label, t) => write!(f, "extfun {label} {t}"),
             Value::FixPoint(i) => write!(f, "fixpoint {i}"),
             Value::State(v) => write!(f, "state({})", *v),
@@ -64,15 +64,15 @@ impl std::fmt::Display for Instruction {
             Instruction::Alloc(t) => write!(f, "alloc {t}"),
             Instruction::Load(src) => write!(f, "load {src}"),
             Instruction::Store(dst, src) => write!(f, "store {dst}, {src}"),
-            Instruction::Call(fptr, args) => {
+            Instruction::Call(fptr, args, _nret) => {
                 write!(f, "call {} [{}]", *fptr, format_vec!(args))
             }
             Instruction::CallCls(cls, args) => {
                 write!(f, "callcls {} [{}]", *cls, format_vec!(args))
             }
             Instruction::Closure(fun) => {
-                if let Value::Function(idx, _) = fun.as_ref() {
-                    write!(f, "closure {idx}")
+                if let Value::Function(idx, _, nret) = fun.as_ref() {
+                    write!(f, "closure {idx} (nret: {nret})")
                 } else {
                     write!(f, "closure {}", *fun)
                 }

--- a/mimium-lang/src/runtime.rs
+++ b/mimium-lang/src/runtime.rs
@@ -42,7 +42,7 @@ pub fn run_bytecode_test(
 ) -> Result<f64, Vec<Box<dyn ReportableError>>> {
     let retcode = machine.execute_entry(bytecodes, "dsp");
     if retcode >= 0 {
-        Ok(vm::Machine::get_as::<f64>(*machine.get_top()))
+        Ok(vm::Machine::get_as::<f64>(machine.get_top_n(1)[0])) // pick a single value for simplicity
     } else {
         Err(vec![Box::new(Error(ErrorKind::Unknown, 0..0))])
     }

--- a/mimium-lang/src/runtime/vm.rs
+++ b/mimium-lang/src/runtime/vm.rs
@@ -257,8 +257,9 @@ impl Machine {
         //     t,
         // );
     }
-    pub fn get_top(&self) -> &RawVal {
-        self.stack.last().unwrap()
+    pub fn get_top_n(&self, n: usize) -> &[RawVal] {
+        let len = self.stack.len();
+        &self.stack[(len - n)..]
     }
     fn get_upvalue_offset(upper_base: usize, offset: OpenUpValue) -> usize {
         upper_base + offset.0
@@ -297,6 +298,9 @@ impl Machine {
 
     pub fn get_as<T>(v: RawVal) -> T {
         unsafe { std::mem::transmute_copy::<RawVal, T>(&v) }
+    }
+    pub fn get_as_array<T>(v: &[RawVal]) -> &[T] {
+        unsafe { std::mem::transmute_copy::<&[RawVal], &[T]>(&v) }
     }
     pub fn to_value<T>(v: T) -> RawVal {
         assert_eq!(std::mem::size_of::<T>(), 8);
@@ -361,6 +365,7 @@ impl Machine {
         // if cfg!(test) {
         //     log::trace!("{:?}", func);
         // }
+
         loop {
             // if cfg!(debug_assertions) || cfg!(test) ||log::max_level()>=log::Level::Trace{
             //     let mut line = String::new();

--- a/mimium-lang/src/runtime/vm.rs
+++ b/mimium-lang/src/runtime/vm.rs
@@ -394,6 +394,14 @@ impl Machine {
                 Instruction::MoveConst(dst, pos) => {
                     self.set_stack(dst as i64, func.constants[pos as usize]);
                 }
+                Instruction::MoveRange(dst, src, n) => {
+                    for offset in 0..n {
+                        self.set_stack(
+                            (dst + offset) as i64,
+                            self.get_stack((src + offset) as i64),
+                        );
+                    }
+                }
                 Instruction::CallCls(func, nargs, nret_req) => {
                     let addr = self.get_stack(func as i64);
                     let cls_i = Self::get_as::<ClosureIdx>(addr);

--- a/mimium-lang/src/runtime/vm/bytecode.rs
+++ b/mimium-lang/src/runtime/vm/bytecode.rs
@@ -1,3 +1,5 @@
+use crate::types::TypeSize;
+
 pub type Reg = u8; // register position
 pub type ConstPos = u16;
 pub type GlobalPos = u16;
@@ -38,8 +40,8 @@ pub enum Instruction {
     // Close(), // currently not implemented as it is not required unless loop/break is used
     Return0,
     // value start position, Nrets
-    Return(Reg, Reg),
-    //dst,src,time,idx 
+    Return(Reg, TypeSize),
+    //dst,src,time,idx
     Delay(Reg, Reg, Reg),
     Mem(Reg, Reg),
 
@@ -110,7 +112,7 @@ impl std::fmt::Display for Instruction {
             Instruction::Mem(dst, src) => {
                 write!(f, "{:<10} {} {}", "mem", dst, src)
             }
-            Instruction::Return(iret, nret) => write!(f, "{:<10} {} {}", "ret", iret, nret),
+            Instruction::Return(iret, _nret) => write!(f, "{:<10} {}", "ret", iret),
             Instruction::GetUpValue(dst, srcup) => write!(f, "{:<10} {} {}", "getupv", dst, srcup),
             Instruction::SetUpValue(dstup, src) => write!(f, "{:<10} {} {}", "setupv", dstup, src),
             Instruction::GetGlobal(dst, src) => write!(f, "{:<10} {} {}", "getglobal", dst, src),

--- a/mimium-lang/src/runtime/vm/bytecode.rs
+++ b/mimium-lang/src/runtime/vm/bytecode.rs
@@ -112,7 +112,7 @@ impl std::fmt::Display for Instruction {
             Instruction::Mem(dst, src) => {
                 write!(f, "{:<10} {} {}", "mem", dst, src)
             }
-            Instruction::Return(iret, _nret) => write!(f, "{:<10} {}", "ret", iret),
+            Instruction::Return(iret, nret) => write!(f, "{:<10} {} {}", "ret", iret, nret),
             Instruction::GetUpValue(dst, srcup) => write!(f, "{:<10} {} {}", "getupv", dst, srcup),
             Instruction::SetUpValue(dstup, src) => write!(f, "{:<10} {} {}", "setupv", dstup, src),
             Instruction::GetGlobal(dst, src) => write!(f, "{:<10} {} {}", "getglobal", dst, src),

--- a/mimium-lang/src/runtime/vm/bytecode.rs
+++ b/mimium-lang/src/runtime/vm/bytecode.rs
@@ -11,6 +11,8 @@ pub enum Instruction {
     // Destination / Source
     Move(Reg, Reg),
     MoveConst(Reg, ConstPos),
+    // Move the range of registers (e.g. tuple)
+    MoveRange(Reg, Reg, u8),
     // call internal function
     // Function Address,Nargs,Nret
     Call(Reg, u8, u8),
@@ -102,6 +104,17 @@ impl std::fmt::Display for Instruction {
             Instruction::ShiftStatePos(v) => write!(f, "{:<10} {}", "shiftsttpos", v),
             Instruction::Move(dst, src) => write!(f, "{:<10} {} {}", "mov", dst, src),
             Instruction::MoveConst(dst, num) => write!(f, "{:<10} {} {}", "movc", dst, num),
+            Instruction::MoveRange(dst, src, n) => {
+                write!(
+                    f,
+                    "{:<10} {}-{} {}-{}",
+                    "mov",
+                    dst,
+                    dst + n - 1,
+                    src,
+                    src + n - 1
+                )
+            }
 
             Instruction::Closure(dst, src) => {
                 write!(f, "{:<10} {} {}", "closure", dst, src)

--- a/mimium-lang/src/runtime/vm/program.rs
+++ b/mimium-lang/src/runtime/vm/program.rs
@@ -12,7 +12,7 @@ pub struct FuncProto {
     pub constants: Vec<RawVal>,
     // feedvalues are mapped in this vector
     pub state_size: u64,
-    pub delay_sizes:Vec<u64>,
+    pub delay_sizes: Vec<u64>,
 }
 impl FuncProto {
     pub fn new(nparam: usize, nret: usize) -> Self {
@@ -37,8 +37,11 @@ impl FuncProto {
 impl From<&mir::Function> for FuncProto {
     fn from(value: &mir::Function) -> Self {
         Self {
-            nparam: value.args.len().into(),
-            nret: 1,
+            nparam: value.args.len(),
+            nret: match &value.return_type {
+                Some(ty) => ty.size() as _,
+                None => 1, // TODO: what should we do when the type is not inferred yet?
+            },
             upindexes: vec![],
             bytecodes: vec![],
             constants: vec![],

--- a/mimium-lang/src/runtime/vm/test.rs
+++ b/mimium-lang/src/runtime/vm/test.rs
@@ -18,8 +18,8 @@ fn size_of_extern_func() {
 
 //single print function
 fn lib_printi(state: &mut Machine) -> i64 {
-    let v = state.get_top();
-    let i = Machine::get_as::<i64>(*v);
+    let v = state.get_top_n(1)[0];
+    let i = Machine::get_as::<i64>(v);
     println!("{}", i);
     return 1;
 }
@@ -55,7 +55,7 @@ fn closuretest() {
         bytecodes: inner_insts,
         constants: vec![], //no constants in the inner function
         state_size: 0,
-        delay_sizes:vec![]
+        delay_sizes: vec![],
     };
     let inner_insts2 = vec![
         // reg0:beg, reg1: inc
@@ -72,7 +72,7 @@ fn closuretest() {
         upindexes: vec![],
         bytecodes: inner_insts2,
         constants: vec![1u64, 2], // 1, position of inner in global table
-        delay_sizes:vec![],
+        delay_sizes: vec![],
         state_size: 0,
     };
     let main_inst = vec![
@@ -103,7 +103,7 @@ fn closuretest() {
         upindexes: vec![],
         bytecodes: main_inst,
         constants: vec![13u64, 7u64, 1, 0], //13,7, makecounter, print_f
-        delay_sizes:vec![],
+        delay_sizes: vec![],
         state_size: 0,
     };
     let global_fn_table = vec![
@@ -142,7 +142,7 @@ fn rust_closure_test() {
         upindexes: vec![],
         bytecodes: inner_insts,
         constants: vec![0u64, 4u64], //cls, int 4
-        delay_sizes:vec![],
+        delay_sizes: vec![],
         state_size: 0,
     };
     let fns = vec![main_f];
@@ -150,8 +150,8 @@ fn rust_closure_test() {
     let global_fn_table = fnames.into_iter().zip(fns.into_iter()).collect::<Vec<_>>();
     // let mut count = 0;
     let cls = Arc::new(Mutex::new(|m: &mut Machine| {
-        let v = m.get_top();
-        let i = Machine::get_as::<u64>(*v) + 3;
+        let v = m.get_top_n(1)[0];
+        let i = Machine::get_as::<u64>(v) + 3;
         println!("Call from closure: {}", i);
         //?????
         m.set_stack(-1, Machine::to_value(i));

--- a/mimium-lang/src/types.rs
+++ b/mimium-lang/src/types.rs
@@ -29,6 +29,9 @@ pub enum Type {
     Unknown,
 }
 
+// currently, this refers to the number of registers
+pub type TypeSize = u8;
+
 pub type Id = String;
 
 #[derive(Clone, Debug, PartialEq)]
@@ -76,6 +79,20 @@ impl Type {
         F: Fn(Self, Self) -> R,
     {
         todo!()
+    }
+
+    pub fn size(&self) -> TypeSize {
+        match self {
+            Type::Primitive(_) => 1,
+            Type::Array(_ty) => todo!(),
+            Type::Tuple(types) => types.len() as _,
+            Type::Struct(types) => types.len() as _,
+            Type::Function(_, _, _) => 1,
+            Type::Ref(_) => 1,
+            Type::Code(_) => todo!(),
+            Type::Intermediate(_) => 1, // TODO
+            Type::Unknown => todo!(),
+        }
     }
 }
 impl fmt::Display for PType {

--- a/mimium-lang/tests/intergration_test.rs
+++ b/mimium-lang/tests/intergration_test.rs
@@ -15,7 +15,7 @@ fn dsp(){{
     test(2.0)
 }}"
     );
-    let res = run_source_test(&src, times);
+    let res = run_source_test(&src, times, false);
     match res {
         Ok(res) => {
             let ans = [expect].repeat(times as usize);
@@ -50,13 +50,13 @@ fn simple_arithmetic() {
     run_simple_test("1.0+hoge^2.0*1.5", 7.0, 3);
 }
 
-fn run_file_test(path: &str, times: u64) -> Result<Vec<f64>, ()> {
+fn run_file_test(path: &str, times: u64, stereo: bool) -> Result<Vec<f64>, ()> {
     let file: PathBuf = [env!("CARGO_MANIFEST_DIR"), "tests/mmm", path]
         .iter()
         .collect();
     println!("{}", file.to_str().unwrap());
     let (src, _path) = fileloader::load(file.to_string_lossy().to_string()).unwrap();
-    let res = run_source_test(&src, times);
+    let res = run_source_test(&src, times, stereo);
     match res {
         Ok(res) => Ok(res),
         Err(errs) => {
@@ -66,56 +66,64 @@ fn run_file_test(path: &str, times: u64) -> Result<Vec<f64>, ()> {
     }
 }
 
+fn run_file_test_mono(path: &str, times: u64) -> Result<Vec<f64>, ()> {
+    run_file_test(path, times, false)
+}
+
+fn run_file_test_stereo(path: &str, times: u64) -> Result<Vec<f64>, ()> {
+    run_file_test(path, times, true)
+}
+
 #[test]
-fn parser_firstbreak(){
-    let res = run_file_test("parser_firstbreak.mmm", 1).unwrap();
+fn parser_firstbreak() {
+    let res = run_file_test_mono("parser_firstbreak.mmm", 1).unwrap();
     let ans = vec![0.0];
     assert_eq!(res, ans);
 }
 
 #[test]
 fn recursion() {
-    let res = run_file_test("recursion.mmm", 1).unwrap();
+    let res = run_file_test_mono("recursion.mmm", 1).unwrap();
     let ans = vec![5.0];
     assert_eq!(res, ans);
 }
 
 #[test]
 fn counter() {
-    let res = run_file_test("counter.mmm", 10).unwrap();
+    let res = run_file_test_mono("counter.mmm", 10).unwrap();
     let ans = vec![0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0];
     assert_eq!(res, ans);
 }
 #[test]
 fn statefn() {
-    let res = run_file_test("statefn.mmm", 10).unwrap();
+    let res = run_file_test_mono("statefn.mmm", 10).unwrap();
     let ans = vec![0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0];
     assert_eq!(res, ans);
 }
 #[test]
 fn statefn2_same() {
-    let res = run_file_test("statefn2_same.mmm", 3).unwrap();
+    let res = run_file_test_mono("statefn2_same.mmm", 3).unwrap();
     let ans = vec![0.0, 6.0, 12.0];
     assert_eq!(res, ans);
 }
 
 #[test]
 fn statefn2() {
-    let res = run_file_test("statefn2.mmm", 3).unwrap();
+    let res = run_file_test_mono("statefn2.mmm", 3).unwrap();
     let ans = vec![0.0, 8.0, 16.0];
     assert_eq!(res, ans);
 }
 
 #[test]
 fn loopcounter() {
-    let res = run_file_test("loopcounter.mmm", 10).unwrap();
+    let res = run_file_test_mono("loopcounter.mmm", 10).unwrap();
     let ans = vec![0.0, 1.0, 2.0, 3.0, 4.0, 0.0, 1.0, 2.0, 3.0, 4.0];
     assert_eq!(res, ans);
 }
 
 #[test]
 fn primitive_sin() {
-    let res = run_file_test("primitive_sin.mmm", 1).unwrap();
+    let res = run_file_test_mono("primitive_sin.mmm", 1).unwrap();
     let ans = vec![0.0];
     let r = (res[0] - ans[0]).abs() < std::f64::EPSILON;
     assert!(r);
@@ -123,7 +131,7 @@ fn primitive_sin() {
 
 #[test]
 fn sinewave() {
-    let res = run_file_test("sinwave.mmm", 10).unwrap();
+    let res = run_file_test_mono("sinwave.mmm", 10).unwrap();
     let ans = vec![
         0.0,
         0.021408545756451732,
@@ -141,55 +149,55 @@ fn sinewave() {
 
 #[test]
 fn ifblock() {
-    let res = run_file_test("if.mmm", 1).unwrap();
+    let res = run_file_test_mono("if.mmm", 1).unwrap();
     let ans = vec![4120.0];
     assert_eq!(res, ans);
 }
 
 #[test]
 fn letmulti() {
-    let res = run_file_test("let_multi.mmm", 1).unwrap();
+    let res = run_file_test_mono("let_multi.mmm", 1).unwrap();
     let ans = vec![3.0];
     assert_eq!(res, ans);
 }
 
 #[test]
 fn closure_open() {
-    let res = run_file_test("closure_open.mmm", 1).unwrap();
+    let res = run_file_test_mono("closure_open.mmm", 1).unwrap();
     let ans = vec![4.0];
     assert_eq!(res, ans);
 }
 
 #[test]
 fn closure_open_3nested() {
-    let res = run_file_test("closure_open_3nested.mmm", 1).unwrap();
+    let res = run_file_test_mono("closure_open_3nested.mmm", 1).unwrap();
     let ans = vec![2.0];
     assert_eq!(res, ans);
 }
 #[test]
 fn closure_open_inline() {
-    let res = run_file_test("closure_open_inline.mmm", 1).unwrap();
+    let res = run_file_test_mono("closure_open_inline.mmm", 1).unwrap();
     let ans = vec![2.0];
     assert_eq!(res, ans);
 }
 
 #[test]
 fn closure_closed() {
-    let res = run_file_test("closure_closed.mmm", 1).unwrap();
+    let res = run_file_test_mono("closure_closed.mmm", 1).unwrap();
     let ans = vec![-6.0];
     assert_eq!(res, ans);
 }
 
 #[test]
 fn closure_argument() {
-    let res = run_file_test("closure_argument.mmm", 1).unwrap();
+    let res = run_file_test_mono("closure_argument.mmm", 1).unwrap();
     let ans = vec![24.0];
     assert_eq!(res, ans);
 }
 
 #[test]
 fn stateful_closure() {
-    let res = run_file_test("stateful_closure.mmm", 10).unwrap();
+    let res = run_file_test_mono("stateful_closure.mmm", 10).unwrap();
     let ans = vec![
         20.0,
         20.3,
@@ -207,7 +215,7 @@ fn stateful_closure() {
 
 #[test]
 fn hof_state() {
-    let res = run_file_test("hof_state.mmm", 10).unwrap();
+    let res = run_file_test_mono("hof_state.mmm", 10).unwrap();
     let ans = vec![
         0.0,
         0.6000000000000001,

--- a/mimium-lang/tests/intergration_test.rs
+++ b/mimium-lang/tests/intergration_test.rs
@@ -230,3 +230,10 @@ fn hof_state() {
     ];
     assert_eq!(res, ans);
 }
+
+#[test]
+fn simple_stereo() {
+    let res = run_file_test_stereo("simple_stereo.mmm", 3).unwrap();
+    let ans = vec![1.0, 2.0, 1.0, 2.0, 1.0, 2.0];
+    assert_eq!(res, ans);
+}

--- a/mimium-lang/tests/intergration_test.rs
+++ b/mimium-lang/tests/intergration_test.rs
@@ -231,9 +231,9 @@ fn hof_state() {
     assert_eq!(res, ans);
 }
 
-// #[test]
-// fn simple_stereo() {
-//     let res = run_file_test_stereo("simple_stereo.mmm", 3).unwrap();
-//     let ans = vec![1.0, 2.0, 1.0, 2.0, 1.0, 2.0];
-//     assert_eq!(res, ans);
-// }
+#[test]
+fn simple_stereo() {
+    let res = run_file_test_stereo("simple_stereo.mmm", 3).unwrap();
+    let ans = vec![1.0, 2.0, 1.0, 2.0, 1.0, 2.0];
+    assert_eq!(res, ans);
+}

--- a/mimium-lang/tests/intergration_test.rs
+++ b/mimium-lang/tests/intergration_test.rs
@@ -231,9 +231,9 @@ fn hof_state() {
     assert_eq!(res, ans);
 }
 
-#[test]
-fn simple_stereo() {
-    let res = run_file_test_stereo("simple_stereo.mmm", 3).unwrap();
-    let ans = vec![1.0, 2.0, 1.0, 2.0, 1.0, 2.0];
-    assert_eq!(res, ans);
-}
+// #[test]
+// fn simple_stereo() {
+//     let res = run_file_test_stereo("simple_stereo.mmm", 3).unwrap();
+//     let ans = vec![1.0, 2.0, 1.0, 2.0, 1.0, 2.0];
+//     assert_eq!(res, ans);
+// }

--- a/mimium-lang/tests/mmm/simple_stereo.mmm
+++ b/mimium-lang/tests/mmm/simple_stereo.mmm
@@ -1,0 +1,7 @@
+fn to_stereo(x:float) -> (float,float) {
+  (x, x * 2.0)
+}
+
+fn dsp() {
+    to_stereo(1.0)
+}

--- a/mimium-lang/tests/mmm/simple_stereo.mmm
+++ b/mimium-lang/tests/mmm/simple_stereo.mmm
@@ -3,5 +3,5 @@ fn to_stereo(x:float) -> (float,float) {
 }
 
 fn dsp() {
-    to_stereo(1.0)
+  to_stereo(1.0)
 }


### PR DESCRIPTION
~~This pull request addresses #8 only very partially. I was hoping I could implement generation of MIR and bytecode, but it seems I'm still far from it. So, let me open this pull request for now.~~

Update: this pull request now adds a barely-working support for tuple.

Now the code like this

```
fn to_stereo(x:float) -> (float,float) {
  (x, x)
}

fn dsp() {
    to_stereo(1.0)
}
```

can be parsed to the following AST.

```
(let
    _mimium_global
    (lambda
       ()
       (let
          to_stereo
          (lambda
             (
                (tid
                   x
                   number))
             (tuple
                (x
                   x)))
          (let
             dsp
             (lambda
                ()
                (app
                   to_stereo
                   (
                      (float
                         1.0))))
             )))
    )
```
