### PR TITLE
nit: Pass colors from ColorGenerator

### DIFF
--- a/mimium-lang/src/compiler/parser/error.rs
+++ b/mimium-lang/src/compiler/parser/error.rs
@@ -35,7 +35,7 @@ where
     fn get_span(&self) -> Span {
         self.0.span()
     }
-    fn get_message(&self) -> String {
+    fn get_message(&self, color: Color) -> String {
         match self.0.reason() {
             chumsky::error::SimpleReason::Unexpected
             | chumsky::error::SimpleReason::Unclosed { .. } => {
@@ -47,7 +47,7 @@ where
                         "unexpected end of input"
                     },
                     if let Some(label) = self.0.label() {
-                        format!(" while parsing {}", label.fg(Color::Green))
+                        format!(" while parsing {}", label.fg(color))
                     } else {
                         " something else".to_string()
                     },
@@ -68,14 +68,14 @@ where
             chumsky::error::SimpleReason::Custom(msg) => msg.clone(),
         }
     }
-    fn get_label(&self) -> String {
+    fn get_label(&self, color: Color) -> String {
         match self.0.reason() {
             chumsky::error::SimpleReason::Custom(msg) => msg.clone(),
             _ => format!(
                 "Unexpected {}",
                 self.0
                     .found()
-                    .map(|c| format!("token {}", c.fg(Color::Red)))
+                    .map(|c| format!("token {}", c.fg(color)))
                     .unwrap_or_else(|| "end of input".to_string())
             ),
         }

--- a/mimium-lang/src/utils/error.rs
+++ b/mimium-lang/src/utils/error.rs
@@ -1,15 +1,15 @@
-use ariadne::{Label, Report, ReportKind, Source};
+use ariadne::{Color, ColorGenerator, Label, Report, ReportKind, Source};
 use std::path;
 
 pub trait ReportableError: std::error::Error {
     /// message is used for reporting verbose message for ariadne.
     ///
     fn get_span(&self) -> std::ops::Range<usize>;
-    fn get_message(&self) -> String {
+    fn get_message(&self, _color: Color) -> String {
         self.to_string()
     }
     /// label is used for indicating error with the specific position for ariadne.
-    fn get_label(&self) -> String {
+    fn get_label(&self, _color: Color) -> String {
         self.to_string()
     }
 }
@@ -19,21 +19,26 @@ where
     T: AsRef<path::Path>,
 {
     let path = srcpath.as_ref().to_str().unwrap_or_default();
+    let mut colors = ColorGenerator::new();
     for e in errs {
+        let color = colors.next();
         let span = e.get_span();
-        // let a_span = (src.source(), span);
+        // let a_span = (src.source(), span);color
+        let label = Label::new((path, span.clone()))
+            .with_message(e.get_label(color))
+            .with_color(color);
         let builder = Report::build(ReportKind::Error, "test", 4)
-            .with_message(e.get_message().as_str())
-            .with_label(Label::new((path, span.clone())).with_message(e.get_label().as_str()))
+            .with_message(e.get_message(color))
+            .with_label(label)
             .finish();
-        builder.eprint((path, Source::from(src.as_str()))).unwrap();
+        builder.eprint((path, Source::from(src))).unwrap();
     }
 }
 
 pub fn dump_to_string(errs: &Vec<Box<dyn ReportableError>>) -> String {
     let mut res = String::new();
     for e in errs {
-        res += e.get_message().as_str();
+        res += e.get_message(Color::Green).as_str();
     }
     res
 }


### PR DESCRIPTION
As [Ariadne's example code](https://docs.rs/ariadne/latest/ariadne/) shows, `ColorGenerator` can generate a color per error. Currently, this is not very useful, but this can look nice when the parser gets smarter. If you prefer the plain red and green (or any other colors), that's also fine to me.

**Before**

![image](https://github.com/user-attachments/assets/b2b49921-5f7a-406a-b559-891dd7546312)

**After**

![image](https://github.com/user-attachments/assets/37d8f833-c2cc-46b2-b47a-4489438a9397)

(Btw, it seems "Er" in the first red "Error" somehow disappears)