### PR TITLE
[PoC] Add "expression statement"

### DIFF
--- a/mimium-lang/src/ast.rs
+++ b/mimium-lang/src/ast.rs
@@ -44,6 +44,8 @@ pub enum Expr {
     Bracket(Box<WithMeta<Self>>),
     Escape(Box<WithMeta<Self>>),
 
+    ExprStmt(Box<WithMeta<Self>>, Option<Box<WithMeta<Self>>>),
+
     Error,
 }
 
@@ -130,6 +132,11 @@ impl MiniPrint for Expr {
                 cond.0.simple_print(),
                 then.0.simple_print(),
                 optelse.as_ref().map_or("".into(), |e| e.0.simple_print())
+            ),
+            Expr::ExprStmt(body, then) => format!(
+                "({} {})",
+                body.0.simple_print(),
+                then.as_ref().map_or("".into(), |t| t.0.simple_print())
             ),
             Expr::Bracket(_) => todo!(),
             Expr::Escape(_) => todo!(),

--- a/mimium-lang/src/ast_interpreter.rs
+++ b/mimium-lang/src/ast_interpreter.rs
@@ -359,6 +359,13 @@ pub fn eval_ast(
                     .unwrap_or(Ok(Value::Primitive(PValue::Unit)))
             }
         }
+        ast::Expr::ExprStmt(e, then) => {
+            eval_ast(e, ctx)?;
+            match then {
+                Some(t) => eval_ast(t, ctx),
+                None => Ok(Value::Primitive(PValue::Unit)),
+            }
+        }
         ast::Expr::Bracket(_) => todo!(),
         ast::Expr::Escape(_) => todo!(),
         ast::Expr::Error => panic!("Some Error happend in previous stages"),

--- a/mimium-lang/src/compiler/mirgen.rs
+++ b/mimium-lang/src/compiler/mirgen.rs
@@ -673,6 +673,14 @@ impl Context {
                 let res = self.push_inst(Instruction::Phi(t, e));
                 Ok((res, thent))
             }
+            Expr::ExprStmt(body, then) => {
+                self.eval_expr(body)?;
+                if let Some(then_e) = then {
+                    self.eval_expr(then_e)
+                } else {
+                    Ok((Arc::new(Value::None), unit!()))
+                }
+            }
             Expr::Bracket(_) => todo!(),
             Expr::Escape(_) => todo!(),
             Expr::Error => todo!(),

--- a/mimium-lang/src/compiler/parser.rs
+++ b/mimium-lang/src/compiler/parser.rs
@@ -2,7 +2,9 @@ use crate::ast::*;
 use crate::types::{PType, Type, TypedId};
 use crate::utils::error::ReportableError;
 use crate::utils::metadata::*;
+use chumsky::combinator::Or;
 use chumsky::prelude::*;
+use chumsky::primitive::Just;
 use chumsky::Parser;
 mod token;
 use token::{Comment, Op, Token};
@@ -46,351 +48,412 @@ fn type_parser() -> impl Parser<Token, Type, Error = Simple<Token>> + Clone {
     })
 }
 
-fn val_parser() -> impl Parser<Token, Expr, Error = Simple<Token>> + Clone {
-    select! {
-        Token::Ident(s) => Expr::Var(s,None),
-        Token::Int(x) => Expr::Literal(Literal::Int(x)),
-        Token::Float(x) =>Expr::Literal(Literal::Float(x.parse().unwrap())),
-        Token::Str(s) => Expr::Literal(Literal::String(s)),
-        Token::SelfLit => Expr::Literal(Literal::SelfLit),
-        Token::Now => Expr::Literal(Literal::Now),
-    }
-    // .map_with_span(|e, s| WithMeta(e, s))
-    .labelled("value")
-}
 fn lvar_parser() -> impl Parser<Token, TypedId, Error = Simple<Token>> + Clone {
     select! { Token::Ident(s) => s }
         .then(just(Token::Colon).ignore_then(type_parser()).or_not())
-        .map(|(id, t)| TypedId { id: id, ty: t })
+        .map(|(id, ty)| TypedId { id, ty })
         .labelled("lvar")
 }
 
-fn expr_parser() -> impl Parser<Token, WithMeta<Expr>, Error = Simple<Token>> + Clone {
-    let lvar = lvar_parser();
-    let val = val_parser();
-    let expr_group = recursive(|expr_group| {
-        let expr = recursive(|expr| {
-            let parenexpr = expr
-                .clone()
-                .delimited_by(just(Token::ParenBegin), just(Token::ParenEnd))
-                .labelled("paren_expr");
-            let let_e = just(Token::Let)
-                .ignore_then(lvar.clone())
-                .then_ignore(just(Token::Assign))
-                .then(expr.clone())
-                .then_ignore(just(Token::LineBreak).or(just(Token::SemiColon)).repeated())
-                .then(expr_group.clone().map(|e| Box::new(e)).or_not())
-                .map(|((ident, body), then)| Expr::Let(ident, Box::new(body), then))
-                .boxed()
-                .labelled("let");
-            let lambda = lvar
-                .clone()
-                .map_with_span(|id, span| WithMeta::<TypedId>(id, span))
-                .separated_by(just(Token::Comma))
-                .delimited_by(
-                    just(Token::LambdaArgBeginEnd),
-                    just(Token::LambdaArgBeginEnd),
-                )
-                .then(just(Token::Arrow).ignore_then(type_parser()).or_not())
-                .then(expr_group.clone())
-                .map(|((ids, r_type), body)| Expr::Lambda(ids, r_type, Box::new(body)))
-                .labelled("lambda");
-
-            let macro_expand = select! { Token::MacroExpand(s) => Expr::Var(s,None) }
-                .map_with_span(|e, s| WithMeta(e, s))
-                .then_ignore(just(Token::ParenBegin))
-                .then(expr_group.clone())
-                .then_ignore(just(Token::ParenEnd))
-                .map_with_span(|(id, then), s| {
-                    Expr::Escape(Box::new(WithMeta(
-                        Expr::Apply(Box::new(id), vec![then]),
-                        s.clone(),
-                    )))
-                })
-                .labelled("macroexpand");
-
-            let tuple = expr
-                .clone()
-                .separated_by(just(Token::Comma))
-                .allow_trailing()
-                .delimited_by(just(Token::ParenBegin), just(Token::ParenEnd))
-                .map_with_span(|e, s| WithMeta(Expr::Tuple(e), s))
-                .labelled("tuple");
-
-            let atom = val
-                .or(lambda)
-                .or(macro_expand)
-                .or(let_e)
-                .map_with_span(|e, s| WithMeta(e, s))
-                .or(parenexpr)
-                .or(tuple)
-                .boxed()
-                .labelled("atoms");
-
-            let items = expr
-                .clone()
-                .separated_by(just(Token::Comma))
-                .allow_trailing()
-                .collect::<Vec<_>>();
-
-            let parenitems = items
-                .clone()
-                .delimited_by(just(Token::ParenBegin), just(Token::ParenEnd))
-                .map_with_span(|e, s| WithMeta(e, s))
-                .repeated();
-            let folder = |f: WithMeta<Expr>, args: WithMeta<Vec<WithMeta<Expr>>>| {
-                WithMeta(
-                    Expr::Apply(Box::new(f.clone()), args.0),
-                    f.1.start..args.1.end,
-                )
-            };
-            let apply = atom.then(parenitems).foldl(folder).labelled("apply");
-
-            let unary = select! { Token::Op(Op::Minus) => {} }
-                .repeated()
-                .then(apply)
-                .foldr(|_op, rhs| {
-                    let rhs_start = rhs.1.start;
-                    let op_start = rhs_start - 1;
-                    let span_end = rhs.1.end;
-                    let neg_op = Box::new(WithMeta(
-                        Expr::Var("neg".to_string(), None),
-                        op_start..rhs_start,
-                    ));
-                    WithMeta(
-                        Expr::Apply(neg_op, vec![WithMeta(rhs.0, rhs.1)]),
-                        op_start..span_end,
-                    )
-                })
-                .labelled("unary");
-
-            let op_cls = |x: WithMeta<_>, y: WithMeta<_>, op: Op, opspan: Span| {
-                WithMeta(
-                    Expr::Apply(
-                        Box::new(WithMeta(
-                            Expr::Var(op.get_associated_fn_name().to_string(), None),
-                            opspan,
-                        )),
-                        vec![x.clone(), y.clone()],
-                    ),
-                    x.1.start..y.1.end,
-                )
-            };
-            let optoken = move |o: Op| {
-                just(Token::Op(o)).map_with_span(|e, s| {
-                    (
-                        match e {
-                            Token::Op(o) => o,
-                            _ => Op::Unknown(String::from("invalid")),
-                        },
-                        s,
-                    )
-                })
-            };
-
-            let op = optoken(Op::Exponent);
-            let exponent = unary
-                .clone()
-                .then(op.then(unary).repeated())
-                .foldl(move |x, ((op, opspan), y)| op_cls(x, y, op, opspan))
-                .boxed();
-            let op = choice((
-                optoken(Op::Product),
-                optoken(Op::Divide),
-                optoken(Op::Modulo),
-            ));
-            let product = exponent
-                .clone()
-                .then(op.then(exponent).repeated())
-                .foldl(move |x, ((op, opspan), y)| op_cls(x, y, op, opspan))
-                .boxed();
-            let op = optoken(Op::Sum).or(optoken(Op::Minus));
-            let add = product
-                .clone()
-                .then(op.then(product).repeated())
-                .foldl(move |x, ((op, opspan), y)| op_cls(x, y, op, opspan))
-                .boxed();
-
-            let op = optoken(Op::Equal).or(optoken(Op::NotEqual));
-
-            let cmp = add
-                .clone()
-                .then(op.then(add).repeated())
-                .foldl(move |x, ((op, opspan), y)| op_cls(x, y, op, opspan))
-                .boxed();
-            let op = optoken(Op::And);
-            let cmp = cmp
-                .clone()
-                .then(op.then(cmp).repeated())
-                .foldl(move |x, ((op, opspan), y)| op_cls(x, y, op, opspan))
-                .boxed();
-            let op = optoken(Op::Or);
-            let cmp = cmp
-                .clone()
-                .then(op.then(cmp).repeated())
-                .foldl(move |x, ((op, opspan), y)| op_cls(x, y, op, opspan))
-                .boxed();
-            let op = choice((
-                optoken(Op::LessThan),
-                optoken(Op::LessEqual),
-                optoken(Op::GreaterThan),
-                optoken(Op::GreaterEqual),
-            ));
-            let cmp = cmp
-                .clone()
-                .then(op.then(cmp).repeated())
-                .foldl(move |x, ((op, opspan), y)| op_cls(x, y, op, opspan))
-                .boxed();
-            let op = optoken(Op::Pipe);
-
-            let pipe = cmp
-                .clone()
-                .then(op.then(cmp).repeated())
-                .foldl(|lhs, ((_, _), rhs)| {
-                    let span = lhs.1.start..rhs.1.end;
-                    WithMeta(Expr::Apply(Box::new(rhs), vec![lhs]), span)
-                })
-                .boxed();
-
-            pipe
-        });
-        // expr_group contains let statement, assignment statement, function definiton,... they cannot be placed as an argument for apply directly.
-
-        let block = expr_group
-            .clone()
-            .padded_by(just(Token::LineBreak).or_not())
-            .delimited_by(just(Token::BlockBegin), just(Token::BlockEnd))
-            .map(|e: WithMeta<Expr>| Expr::Block(Some(Box::new(e))));
-
-        //todo: should be recursive(to paranthes be not needed)
-        let if_ = just(Token::If)
-            .ignore_then(
-                expr_group
-                    .clone()
-                    .delimited_by(just(Token::ParenBegin), just(Token::ParenEnd)),
-            )
-            .then(expr_group.clone())
-            .then(
-                just(Token::Else)
-                    .ignore_then(expr_group.clone().map(|e| Box::new(e)))
-                    .or_not(),
-            )
-            .map_with_span(|((cond, then), opt_else), s| {
-                WithMeta(Expr::If(cond.into(), then.into(), opt_else), s)
-            })
-            .labelled("if");
-
-        block
-            .map_with_span(|e, s| WithMeta(e, s))
-            .or(if_)
-            .or(expr.clone())
-    });
-    expr_group
-}
 fn comment_parser() -> impl Parser<Token, (), Error = Simple<Token>> + Clone {
-    select! {Token::Comment(Comment::SingleLine(t))=>(),
-    Token::Comment(Comment::MultiLine(t))=>()}
+    select! {Token::Comment(Comment::SingleLine(_))=>(),
+    Token::Comment(Comment::MultiLine(_))=>()}
 }
-fn func_parser() -> impl Parser<Token, WithMeta<Expr>, Error = Simple<Token>> + Clone {
-    let expr = expr_parser();
-    let lvar = lvar_parser();
-    let blockstart = just(Token::BlockBegin)
-        .then_ignore(just(Token::LineBreak).or(just(Token::SemiColon)).repeated());
-    let blockend = just(Token::LineBreak)
-        .or(just(Token::SemiColon))
-        .repeated()
-        .ignore_then(just(Token::BlockEnd));
-    let fnparams = lvar
+
+#[allow(clippy::type_complexity)]
+fn eol() -> Or<Just<Token, Token, Simple<Token>>, Just<Token, Token, Simple<Token>>> {
+    just(Token::LineBreak).or(just(Token::SemiColon))
+}
+
+fn stmt_parser() -> impl Parser<Token, WithMeta<Expr>, Error = Simple<Token>> + Clone {
+    recursive(|stmt| {
+        // Note: this needs to be declare() first instead of recursive()
+        // directly because otherwise the dependency cannot be described.
+        let mut expr = Recursive::<Token, WithMeta<Expr>, Simple<Token>>::declare();
+        let mut non_block_expr = Recursive::<Token, WithMeta<Expr>, Simple<Token>>::declare();
+        let mut block_expr = Recursive::<Token, WithMeta<Expr>, Simple<Token>>::declare();
+
+        expr.define(non_block_expr.clone().or(block_expr.clone()));
+        non_block_expr.define(non_block_expr_parser(expr.clone()));
+        block_expr.define(block_expr_parser(expr.clone()));
+
+        let expr_stmt = expr_stmt_parser(expr.clone(), stmt.clone());
+        let let_stmt = let_stmt_parser(expr.clone(), stmt.clone());
+        let func_decl = func_decl_parser(block_expr.clone(), stmt.clone());
+        let macro_decl = macro_decl_parser(block_expr.clone(), expr.clone());
+
+        expr_stmt.or(let_stmt).or(func_decl).or(macro_decl)
+    })
+}
+
+fn op_parser<'a, P>(
+    expr: P,
+    ops: Vec<Op>,
+) -> impl Parser<Token, WithMeta<Expr>, Error = Simple<Token>> + Clone + 'a
+where
+    P: Parser<Token, WithMeta<Expr>, Error = Simple<Token>> + Clone + 'a,
+{
+    let op_cls = |x: WithMeta<_>, y: WithMeta<_>, op: Op, opspan: Span| {
+        WithMeta(
+            Expr::Apply(
+                Box::new(WithMeta(
+                    Expr::Var(op.get_associated_fn_name().to_string(), None),
+                    opspan,
+                )),
+                vec![x.clone(), y.clone()],
+            ),
+            x.1.start..y.1.end,
+        )
+    };
+    let optoken = move |o: Op| {
+        just(Token::Op(o)).map_with_span(|e, s| {
+            (
+                match e {
+                    Token::Op(o) => o,
+                    _ => Op::Unknown(String::from("invalid")),
+                },
+                s,
+            )
+        })
+    };
+
+    let lhs = expr.clone();
+    let rhs = expr;
+
+    let ops: Vec<_> = ops.into_iter().map(optoken).collect();
+
+    lhs.then(choice(ops).then(rhs).repeated())
+        .foldl(move |x, ((op, opspan), y)| op_cls(x, y, op, opspan))
+        .boxed()
+}
+
+fn non_block_expr_parser<'a>(
+    expr: impl Parser<Token, WithMeta<Expr>, Error = Simple<Token>> + Clone + 'a,
+) -> impl Parser<Token, WithMeta<Expr>, Error = Simple<Token>> + Clone + 'a {
+    let atom = literal_expr_parser()
+        .or(symbol_expr_parser())
+        .or(grouped_expr_parser(expr.clone()))
+        .or(tuple_expr_parser(expr.clone()))
+        .or(lambda_expr_parser(expr.clone()))
+        .or(macro_expand_expr_parser(expr.clone()))
+        .boxed()
+        .labelled("atom");
+
+    // call expression
+
+    let parenitem = atom
         .clone()
-        .map_with_span(|e, s| WithMeta(e, s))
+        .separated_by(just(Token::Comma))
+        .allow_trailing()
+        .delimited_by(just(Token::ParenBegin), just(Token::ParenEnd))
+        .map_with_span(WithMeta);
+
+    let folder = |f: WithMeta<Expr>, args: WithMeta<Vec<WithMeta<Expr>>>| {
+        WithMeta(
+            Expr::Apply(Box::new(f.clone()), args.0),
+            f.1.start..args.1.end,
+        )
+    };
+    let apply = atom
+        // Note: repeated() means including 0, so this contains non-apply expression
+        .then(parenitem.repeated())
+        .foldl(folder)
+        .labelled("apply");
+
+    // unary operator expression
+
+    let unary = select! { Token::Op(Op::Minus) => {} }
+        .repeated()
+        .then(apply)
+        .foldr(|_op, rhs| {
+            // TODO: ideally, span should include the minus, but it
+            // seems there's no information about how many spaces
+            // between the minus and the value.
+            let span = rhs.1.clone();
+
+            let neg_op = Box::new(WithMeta(Expr::Var("neg".to_string(), None), span.clone()));
+            WithMeta(Expr::Apply(neg_op, vec![rhs]), span.clone())
+        })
+        .labelled("unary");
+
+    // binary operator expression
+
+    let exponent = op_parser(unary, vec![Op::Exponent]);
+    let product = op_parser(exponent, vec![Op::Product, Op::Divide, Op::Modulo]);
+    let add = op_parser(product, vec![Op::Sum, Op::Minus]);
+    let cmp_eq = op_parser(add, vec![Op::Equal, Op::NotEqual]);
+    let cnd_and = op_parser(cmp_eq, vec![Op::And]);
+    let cnd_or = op_parser(cnd_and, vec![Op::Or]);
+    let cmp = op_parser(
+        cnd_or,
+        vec![
+            Op::LessThan,
+            Op::LessEqual,
+            Op::GreaterThan,
+            Op::GreaterEqual,
+        ],
+    );
+
+    let pipe_op = just(Token::Op(Op::Pipe)).map_with_span(|e, s| {
+        (
+            match e {
+                Token::Op(o) => o,
+                _ => Op::Unknown(String::from("invalid")),
+            },
+            s,
+        )
+    });
+    cmp.clone()
+        .then(pipe_op.then(cmp).repeated())
+        .foldl(|lhs, ((_, _), rhs)| {
+            let span = lhs.1.start..rhs.1.end;
+            WithMeta(Expr::Apply(Box::new(rhs), vec![lhs]), span)
+        })
+        .boxed()
+}
+
+fn block_expr_parser<'a>(
+    expr: impl Parser<Token, WithMeta<Expr>, Error = Simple<Token>> + Clone + 'a,
+    // stmt: impl Parser<Token, WithMeta<Expr>, Error = Simple<Token>> + Clone + 'a,
+) -> impl Parser<Token, WithMeta<Expr>, Error = Simple<Token>> + Clone + 'a {
+    let blockstart = just(Token::BlockBegin).then_ignore(eol().repeated());
+    let blockend = eol().repeated().ignore_then(just(Token::BlockEnd));
+
+    // TODO?: Semantically, this should be { stmt* expr eol? } | { expr eol? } | {}
+    //        But, using expr instead of stmt makes this simple and just works.
+    let bracketed_block = expr
+        .clone()
+        .separated_by(eol())
+        .delimited_by(blockstart, blockend)
+        .map_with_span(|e, s| {
+            match e.as_slice() {
+                [] => WithMeta(Expr::Block(None), s),
+                [e] => {
+                    let inner = WithMeta(Expr::ExprStmt(Box::new(e.clone()), None), e.1.clone());
+                    WithMeta(Expr::Block(Some(Box::new(inner))), s)
+                }
+                // fold into a chain of ExprStmt
+                [head @ .., last] => head.iter().rfold(last.clone(), |acc, x| {
+                    WithMeta(
+                        Expr::ExprStmt(Box::new(x.clone()), Some(Box::new(acc))),
+                        x.1.clone(),
+                    )
+                }),
+            }
+        })
+        .labelled("bracket");
+
+    let if_block = just(Token::If)
+        .ignore_then(
+            expr.clone()
+                .delimited_by(just(Token::ParenBegin), just(Token::ParenEnd)),
+        )
+        .then(bracketed_block.clone())
+        .then(
+            just(Token::Else)
+                .ignore_then(bracketed_block.clone().map(Box::new))
+                .or_not(),
+        )
+        .map_with_span(|((cond, then), opt_else), s| {
+            WithMeta(Expr::If(cond.into(), then.into(), opt_else), s)
+        })
+        .labelled("if");
+
+    bracketed_block.or(if_block)
+}
+
+fn literal_expr_parser() -> impl Parser<Token, WithMeta<Expr>, Error = Simple<Token>> + Clone {
+    select! {
+        Token::Int(x) => Expr::Literal(Literal::Int(x)),
+        Token::Float(x) =>Expr::Literal(Literal::Float(x.parse().unwrap())),
+        Token::Str(s) => Expr::Literal(Literal::String(s)),
+    }
+    .map_with_span(WithMeta)
+    .labelled("literal")
+}
+
+fn symbol_expr_parser() -> impl Parser<Token, WithMeta<Expr>, Error = Simple<Token>> + Clone {
+    select! {
+        Token::Ident(s) => Expr::Var(s,None),
+        Token::SelfLit => Expr::Literal(Literal::SelfLit),
+        Token::Now => Expr::Literal(Literal::Now),
+    }
+    .map_with_span(WithMeta)
+    .labelled("expr")
+}
+
+fn grouped_expr_parser<'a>(
+    expr: impl Parser<Token, WithMeta<Expr>, Error = Simple<Token>> + Clone + 'a,
+) -> impl Parser<Token, WithMeta<Expr>, Error = Simple<Token>> + Clone + 'a {
+    expr.delimited_by(just(Token::ParenBegin), just(Token::ParenEnd))
+        .labelled("paren_expr")
+}
+
+fn tuple_expr_parser<'a>(
+    expr: impl Parser<Token, WithMeta<Expr>, Error = Simple<Token>> + Clone + 'a,
+) -> impl Parser<Token, WithMeta<Expr>, Error = Simple<Token>> + Clone + 'a {
+    expr.separated_by(just(Token::Comma))
+        .allow_trailing()
+        .delimited_by(just(Token::ParenBegin), just(Token::ParenEnd))
+        .map_with_span(|e, s| WithMeta(Expr::Tuple(e), s))
+        .labelled("tuple")
+}
+
+fn lambda_expr_parser<'a>(
+    expr: impl Parser<Token, WithMeta<Expr>, Error = Simple<Token>> + Clone + 'a,
+) -> impl Parser<Token, WithMeta<Expr>, Error = Simple<Token>> + Clone + 'a {
+    lvar_parser()
+        .map_with_span(WithMeta)
+        .separated_by(just(Token::Comma))
+        .delimited_by(
+            just(Token::LambdaArgBeginEnd),
+            just(Token::LambdaArgBeginEnd),
+        )
+        .then(just(Token::Arrow).ignore_then(type_parser()).or_not())
+        .then(expr)
+        .map_with_span(|((ids, r_type), body), s| {
+            WithMeta(Expr::Lambda(ids, r_type, Box::new(body)), s)
+        })
+        .labelled("lambda")
+}
+
+fn macro_expand_expr_parser<'a>(
+    expr: impl Parser<Token, WithMeta<Expr>, Error = Simple<Token>> + Clone + 'a,
+) -> impl Parser<Token, WithMeta<Expr>, Error = Simple<Token>> + Clone + 'a {
+    select! { Token::MacroExpand(s) => Expr::Var(s,None) }
+        .map_with_span(WithMeta)
+        .then_ignore(just(Token::ParenBegin))
+        .then(expr)
+        .then_ignore(just(Token::ParenEnd))
+        .map_with_span(|(id, then), s| {
+            WithMeta(
+                Expr::Escape(Box::new(WithMeta(
+                    Expr::Apply(Box::new(id), vec![then]),
+                    s.clone(),
+                ))),
+                s,
+            )
+        })
+        .labelled("macroexpand")
+}
+
+fn expr_stmt_parser<'a>(
+    expr: impl Parser<Token, WithMeta<Expr>, Error = Simple<Token>> + Clone + 'a,
+    stmt: impl Parser<Token, WithMeta<Expr>, Error = Simple<Token>> + Clone + 'a,
+) -> impl Parser<Token, WithMeta<Expr>, Error = Simple<Token>> + Clone + 'a {
+    expr.then_ignore(eol().repeated().at_least(1))
+        .then(stmt.map(Box::new).or_not())
+        .map_with_span(|(expr_body, then), span| {
+            WithMeta(Expr::ExprStmt(Box::new(expr_body), then), span)
+        })
+        .boxed()
+        .labelled("expression statement")
+}
+
+fn let_stmt_parser<'a>(
+    expr: impl Parser<Token, WithMeta<Expr>, Error = Simple<Token>> + Clone + 'a,
+    stmt: impl Parser<Token, WithMeta<Expr>, Error = Simple<Token>> + Clone + 'a,
+) -> impl Parser<Token, WithMeta<Expr>, Error = Simple<Token>> + Clone + 'a {
+    just(Token::Let)
+        .ignore_then(lvar_parser())
+        .then_ignore(just(Token::Assign))
+        .then(expr)
+        .then_ignore(eol().repeated().at_least(1))
+        .then(stmt.map(Box::new).or_not())
+        .map_with_span(|((ident, body), then), span| {
+            WithMeta(Expr::Let(ident, Box::new(body), then), span)
+        })
+        .boxed()
+        .labelled("let_stmt")
+}
+
+fn fnparams_parser<'a>(
+    lvar: impl Parser<Token, TypedId, Error = Simple<Token>> + Clone + 'a,
+) -> impl Parser<Token, Vec<WithMeta<TypedId>>, Error = Simple<Token>> + Clone + 'a {
+    lvar.map_with_span(WithMeta)
         .separated_by(just(Token::Comma))
         .delimited_by(just(Token::ParenBegin), just(Token::ParenEnd))
-        .labelled("fnparams");
+        .labelled("fnparams")
+}
 
-    let stmt = recursive(|stmt| {
-        let function_s = just(Token::Function)
-            .ignore_then(lvar.clone())
-            .then(fnparams.clone())
-            .then(just(Token::Arrow).ignore_then(type_parser()).or_not())
-            .then(
-                expr.clone()
-                    .delimited_by(blockstart.clone(), blockend.clone()),
-            )
-            .then_ignore(just(Token::LineBreak).or(just(Token::SemiColon)).repeated())
-            .then(stmt.clone().map(|e| Box::new(e)).or_not())
-            .map_with_span(|((((fname, ids), r_type), block), then), s| {
-                let atypes = ids
-                    .iter()
-                    .map(|WithMeta(TypedId { ty, id: _ }, _)| ty.clone().unwrap_or(Type::Unknown))
-                    .collect::<Vec<_>>();
-                let fname = TypedId {
-                    ty: Some(Type::Function(
-                        atypes,
-                        Box::new(r_type.clone().unwrap_or(Type::Unknown)),
-                        None,
+fn func_decl_parser<'a>(
+    block_expr: impl Parser<Token, WithMeta<Expr>, Error = Simple<Token>> + Clone + 'a,
+    stmt: impl Parser<Token, WithMeta<Expr>, Error = Simple<Token>> + Clone + 'a,
+) -> impl Parser<Token, WithMeta<Expr>, Error = Simple<Token>> + Clone + 'a {
+    let lvar = lvar_parser();
+    let fnparams = fnparams_parser(lvar.clone());
+
+    just(Token::Function)
+        .ignore_then(lvar)
+        .then(fnparams)
+        .then(just(Token::Arrow).ignore_then(type_parser()).or_not())
+        .then(block_expr.clone())
+        .then_ignore(just(Token::LineBreak).or(just(Token::SemiColon)).repeated())
+        .then(stmt.clone().map(Box::new).or_not())
+        .map_with_span(|((((fname, ids), r_type), block), then), s| {
+            let atypes = ids
+                .iter()
+                .map(|WithMeta(TypedId { ty, id: _ }, _)| ty.clone().unwrap_or(Type::Unknown))
+                .collect::<Vec<_>>();
+            let fname = TypedId {
+                ty: Some(Type::Function(
+                    atypes,
+                    Box::new(r_type.clone().unwrap_or(Type::Unknown)),
+                    None,
+                )),
+                id: fname.id.clone(),
+            };
+            WithMeta(
+                Expr::LetRec(
+                    fname,
+                    Box::new(WithMeta(
+                        Expr::Lambda(ids, r_type, Box::new(block)),
+                        s.clone(),
                     )),
-                    id: fname.id.clone(),
-                };
-                WithMeta(
-                    Expr::LetRec(
-                        fname,
-                        Box::new(WithMeta(
-                            Expr::Lambda(ids, r_type, Box::new(block)),
-                            s.clone(),
-                        )),
-                        then,
-                    ),
-                    s,
-                )
-            })
-            .labelled("function decl");
-        let macro_s = just(Token::Macro)
-            .ignore_then(lvar.clone())
-            .then(fnparams.clone())
-            .then(
-                expr.clone()
-                    .delimited_by(blockstart.clone(), blockend.clone())
-                    .map(|WithMeta(e, s)| {
-                        WithMeta(Expr::Bracket(Box::new(WithMeta(e, s.clone()))), s)
-                    }),
+                    then,
+                ),
+                s,
             )
-            .then(expr.clone().map(|e| Box::new(e)).or_not())
-            .map_with_span(|(((fname, ids), block), then), s| {
-                WithMeta(
-                    Expr::LetRec(
-                        fname,
-                        Box::new(WithMeta(
-                            Expr::Lambda(ids, None, Box::new(block)),
-                            s.clone(),
-                        )),
-                        then,
-                    ),
-                    s,
-                )
-            })
-            .labelled("macro definition");
-        let let_stmt = just(Token::Let)
-            .ignore_then(lvar.clone())
-            .then_ignore(just(Token::Assign))
-            .then(expr.clone())
-            .then_ignore(just(Token::LineBreak).or(just(Token::SemiColon)).repeated())
-            .then(stmt.clone().map(|e| Box::new(e)).or_not())
-            .map_with_span(|((ident, body), then), span| {
-                WithMeta(Expr::Let(ident, Box::new(body), then), span)
-            })
-            .boxed()
-            .labelled("let_stmt");
-        function_s.or(macro_s).or(let_stmt).or(expr_parser())
-    });
-    stmt
-    // expr_parser().then_ignore(end())
+        })
+        .labelled("function decl")
+}
+
+fn macro_decl_parser<'a>(
+    block_expr: impl Parser<Token, WithMeta<Expr>, Error = Simple<Token>> + Clone + 'a,
+    expr: impl Parser<Token, WithMeta<Expr>, Error = Simple<Token>> + Clone + 'a,
+) -> impl Parser<Token, WithMeta<Expr>, Error = Simple<Token>> + Clone + 'a {
+    let lvar = lvar_parser();
+    let fnparams = fnparams_parser(lvar.clone());
+
+    just(Token::Macro)
+        .ignore_then(lvar)
+        .then(fnparams)
+        .then(
+            block_expr
+                .map(|WithMeta(e, s)| WithMeta(Expr::Bracket(Box::new(WithMeta(e, s.clone()))), s)),
+        )
+        .then(expr.clone().map(Box::new).or_not())
+        .map_with_span(|(((fname, ids), block), then), s| {
+            WithMeta(
+                Expr::LetRec(
+                    fname,
+                    Box::new(WithMeta(
+                        Expr::Lambda(ids, None, Box::new(block)),
+                        s.clone(),
+                    )),
+                    then,
+                ),
+                s,
+            )
+        })
+        .labelled("macro definition")
 }
 
 fn parser() -> impl Parser<Token, WithMeta<Expr>, Error = Simple<Token>> + Clone {
     let ignored = comment_parser()
         .or(just(Token::LineBreak).ignored())
         .or(just(Token::SemiColon).ignored());
-    func_parser()
+    stmt_parser()
         .padded_by(ignored.repeated())
         .then_ignore(end())
 }
@@ -431,6 +494,7 @@ pub fn parse(src: &str) -> Result<WithMeta<Expr>, Vec<Box<dyn ReportableError>>>
         Err(errs)
     }
 }
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/mimium-lang/src/compiler/parser.rs
+++ b/mimium-lang/src/compiler/parser.rs
@@ -228,10 +228,7 @@ fn block_expr_parser<'a>(
         .map_with_span(|e, s| {
             match e.as_slice() {
                 [] => WithMeta(Expr::Block(None), s),
-                [e] => {
-                    let inner = WithMeta(Expr::ExprStmt(Box::new(e.clone()), None), e.1.clone());
-                    WithMeta(Expr::Block(Some(Box::new(inner))), s)
-                }
+                [e] => WithMeta(Expr::Block(Some(Box::new(e.clone()))), s),
                 // fold into a chain of ExprStmt
                 [head @ .., last] => head.iter().rfold(last.clone(), |acc, x| {
                     WithMeta(

--- a/mimium-lang/src/compiler/parser/lexer.rs
+++ b/mimium-lang/src/compiler/parser/lexer.rs
@@ -107,7 +107,7 @@ pub fn lexer() -> impl Parser<char, Vec<(Token, Span)>, Error = Simple<char>> {
         .map(|_s| Token::LineBreak);
     // A single token can be one of the above
     let token = comment_parser()
-        .map(|c| Token::Comment(c))
+        .map(Token::Comment)
         .or(float)
         .or(int)
         .or(str_)


### PR DESCRIPTION
(This pull request is mainly to show the basic idea. Probably I'll abandon this and retry after #22 gets merged)

My current interest is to make this work.

```
fn dsp() {
  1.0
  1.0
}
```

At the moment, the parser fails to parse this.

```
Error: unexpected token while parsing function decl, expected linebreak, }, ;
   ╭─[path/to/tmp.mmm:3:3]
   │
 3 │   1.0
   ·   ─┬─
   ·    ╰─── Unexpected token 1.0
───╯
```

This particular example is not really meaningful. But, for example, it's a valid use case to call a function for some side effect, not for the return value.

```
fn foo(x:float) {
  print(x)
  x * 2.0
}
```


The reason of the failure is, if I understand correctly, the current parser allows an expression only either

1. in a statement (`let` statement, `fn` declaration, and `macro` declaration)
2. on the next line of a specific type of statement (`Expr::Let`, `Expr::LetTuple`, and `Expr::LetRec`)
3. as a single line in a `{ }` block

There can be several possible solutions, e.g. let a `Expr::Block` hold a vector of expressions.

In this pull request, I chose to tweak the rule 2; introduce "expression statement" and create a chain of expressions. 

Expression statement is typically defined as following in the case of a language that requires `;`. On the other hand, Mimium is semicolon-less, so, an expression and an expression statement look the same (except when a ';' is explicitly appended). However, I believe these two needs to be somehow distinguished in the implementation if the language has concept of expression and statement.

```
Expression ';'
```

This pull request's approach is incomplete, but seems to work at least to some extent. 

A disclaimer is that, this is based on the mimium's syntax I imagined wildly ([gist](https://gist.github.com/yutannihilation/eb3f3db5cd4a2f388bffd5bf856985c3)), so I might have some misunderstandings on the syntax and semantics!