### PR TITLE
nit: Use `resolver = "2"`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,5 @@ members = [
     "mimium-audiodriver",
     "mimium-cli"
 ]
+
+resolver = "2"


### PR DESCRIPTION
This pull request is just for avoiding this warning. In short, if a package is without a workspace, `edition = "2021"` means `resolver = "2"`. However, if a package is within a workspace, `resolver` needs to be explicitly specified for some reason. There should be no difference on the compilation results.

```
warning: virtual workspace defaulting to `resolver = "1"` despite one or more workspace members being on edition 2021 which implies `resolver = "2"`
note: to keep the current resolver, specify `workspace.resolver = "1"` in the workspace root's manifest
note: to use the edition 2021 resolver, specify `workspace.resolver = "2"` in the workspace root's manifest
note: for more details see https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions
```
