### PR TITLE
Implement Destructive Assignment

### DIFF
--- a/mimium-lang/src/ast.rs
+++ b/mimium-lang/src/ast.rs
@@ -35,7 +35,7 @@ impl Expr {
 #[derive(Clone, Debug, PartialEq)]
 pub enum Expr {
     Literal(Literal),
-    Var(Symbol, Option<Time>),
+    Var(Symbol),
     Block(Option<ExprNodeId>),
     Tuple(Vec<ExprNodeId>),
     Proj(ExprNodeId, i64),
@@ -102,10 +102,7 @@ impl MiniPrint for Expr {
     fn simple_print(&self) -> String {
         match self {
             Expr::Literal(l) => l.simple_print(),
-            Expr::Var(v, t) => match t {
-                Some(t) => format!("{}@{}", v, t),
-                None => v.to_string(),
-            },
+            Expr::Var(v) => format!("{v}"),
             Expr::Block(e) => e.map_or("".to_string(), |eid| {
                 format!("(block {})", eid.to_expr().simple_print())
             }),

--- a/mimium-lang/src/ast.rs
+++ b/mimium-lang/src/ast.rs
@@ -42,7 +42,7 @@ pub enum Expr {
     Apply(ExprNodeId, Vec<ExprNodeId>),
     Lambda(Vec<TypedId>, Option<TypeNodeId>, ExprNodeId), //lambda, maybe information for internal state is needed
     Assign(Symbol, ExprNodeId),
-    Then(ExprNodeId, ExprNodeId),
+    Then(ExprNodeId, Option<ExprNodeId>),
     Feed(Symbol, ExprNodeId), //feedback connection primitive operation. This will be shown only after self-removal stage
     Let(TypedPattern, ExprNodeId, Option<ExprNodeId>),
     LetRec(TypedId, ExprNodeId, Option<ExprNodeId>),

--- a/mimium-lang/src/ast/builder.rs
+++ b/mimium-lang/src/ast/builder.rs
@@ -30,7 +30,7 @@ macro_rules! string {
 #[macro_export]
 macro_rules! var {
     ($n:literal) => {
-        Expr::Var($crate::ast::builder::str_to_symbol($n), None).into_id(0..0)
+        Expr::Var($crate::ast::builder::str_to_symbol($n)).into_id(0..0)
     };
 }
 

--- a/mimium-lang/src/ast_interpreter.rs
+++ b/mimium-lang/src/ast_interpreter.rs
@@ -248,7 +248,7 @@ pub fn eval_ast(e_meta: ExprNodeId, ctx: &mut Context) -> Result<Value, CompileE
     let span = e_meta.to_span();
     match &e_meta.to_expr() {
         ast::Expr::Literal(l) => Ok(eval_literal(l)),
-        ast::Expr::Var(v, _time) => env
+        ast::Expr::Var(v) => env
             .lookup(v)
             .map(|v| v.clone())
             .or(ctx

--- a/mimium-lang/src/compiler/bytecodegen.rs
+++ b/mimium-lang/src/compiler/bytecodegen.rs
@@ -360,7 +360,7 @@ impl ByteCodeGenerator {
             mir::Instruction::Call(v, args, r_ty) => {
                 let rsize = Self::word_size_for_type(*r_ty);
                 match v.as_ref() {
-                    mir::Value::Register(address) => {
+                    mir::Value::Register(_address) => {
                         let bytecodes_dst =
                             bytecodes_dst.unwrap_or_else(|| funcproto.bytecodes.as_mut());
                         let d = self.get_destination(dst.clone(), rsize);
@@ -447,20 +447,20 @@ impl ByteCodeGenerator {
                     Self::word_size_for_type(*ty),
                 ))
             }
-            mir::Instruction::SetUpValue(i, ty) => {
-                let upval = &mirfunc.upindexes[*i as usize];
+            mir::Instruction::SetUpValue(dst, src, ty) => {
+                let upval = &mirfunc.upindexes[*dst as usize];
                 let v = self.find_upvalue(upval);
                 let size: u8 = Self::word_size_for_type(*ty);
                 let ouv = mir::OpenUpValue(v as usize, size);
-                if let Some(ui) = funcproto.upindexes.get_mut(*i as usize) {
+                if let Some(ui) = funcproto.upindexes.get_mut(*dst as usize) {
                     *ui = ouv;
                 } else {
                     funcproto.upindexes.push(ouv);
                 }
-                let d = self.vregister.get_top().add_newvalue_range(&dst, size as _);
+                let s = self.find(src);
                 Some(VmInstruction::SetUpValue(
-                    d,
-                    *i as Reg,
+                    *dst as Reg,
+                    s,
                     Self::word_size_for_type(*ty),
                 ))
             }

--- a/mimium-lang/src/compiler/mirgen.rs
+++ b/mimium-lang/src/compiler/mirgen.rs
@@ -101,12 +101,11 @@ impl Context {
                 }
                 let args = self.eval_args(&[*src, *time])?;
                 let (args, _types): (Vec<VPtr>, Vec<TypeNodeId>) = args.into_iter().unzip();
-                let res = Ok(Some(self.push_inst(Instruction::Delay(
+                Ok(Some(self.push_inst(Instruction::Delay(
                     max_time as u64,
                     args[0].clone(),
                     args[1].clone(),
-                ))));
-                res
+                ))))
             }
             _ => Err(CompileError(
                 CompileErrorKind::UnboundedDelay,
@@ -247,8 +246,7 @@ impl Context {
     ) -> usize {
         let newf = mir::Function::new(name, args, argtypes, parent_i);
         self.program.functions.push(newf);
-        let idx = self.program.functions.len() - 1;
-        idx
+        self.program.functions.len() - 1
     }
     fn do_in_child_ctx<F: FnMut(&mut Self, usize) -> Result<(VPtr, TypeNodeId), CompileError>>(
         &mut self,
@@ -319,7 +317,7 @@ impl Context {
                 }
                 _ => self.push_inst(Instruction::Load(v.clone(), t)),
             },
-            LookupRes::UpValue(level, v) => (0..level).into_iter().rev().fold(v, |upv, i| {
+            LookupRes::UpValue(level, v) => (0..level).rev().fold(v, |upv, i| {
                 let res = self.gen_new_register();
                 let current = self.data.get_mut(self.data_i - i).unwrap();
                 let currentf = self.program.functions.get_mut(current.func_i).unwrap();
@@ -472,7 +470,7 @@ impl Context {
                 let (f, ft) = self.eval_expr(*f)?;
                 let del = self.make_delay(&f, args)?;
                 if let Some(d) = del {
-                    Ok((d, Type::Primitive(PType::Numeric).into_id()))
+                    Ok((d, numeric!()))
                 } else {
                     let atvvec = self.eval_args(args)?;
                     let rt = if let Type::Function(_, rt, _) = ft.to_type() {
@@ -535,8 +533,7 @@ impl Context {
                     .map(|((idx, name), t)| {
                         let label = name.id;
                         let a = Argument(label, *t);
-                        let res = (label, Arc::new(Value::Argument(idx, Arc::new(a))));
-                        res
+                        (label, Arc::new(Value::Argument(idx, Arc::new(a))))
                     })
                     .collect::<Vec<_>>();
 
@@ -567,10 +564,9 @@ impl Context {
                         (_, _) => {
                             if rt.to_type().contains_function() {
                                 let newres = ctx.push_inst(Instruction::CloseUpValue(res.clone()));
-                                let _ =
-                                    ctx.push_inst(Instruction::Return(newres.clone(), rt.clone()));
+                                let _ = ctx.push_inst(Instruction::Return(newres.clone(), rt));
                             } else {
-                                let _ = ctx.push_inst(Instruction::Return(res.clone(), rt.clone()));
+                                let _ = ctx.push_inst(Instruction::Return(res.clone(), rt));
                             }
                         }
                     };
@@ -629,13 +625,12 @@ impl Context {
                         if t.to_type().is_function() {
                             //globally allocated closures are immidiately closed, not to be disposed
                             let b = self.push_inst(Instruction::CloseUpValue(bodyv.clone()));
-                            let _greg =
-                                self.push_inst(Instruction::SetGlobal(gv.clone(), b, t.clone()));
+                            let _greg = self.push_inst(Instruction::SetGlobal(gv.clone(), b, t));
                         } else {
                             let _greg = self.push_inst(Instruction::SetGlobal(
                                 gv.clone(),
                                 bodyv.clone(),
-                                t.clone(),
+                                t,
                             ));
                         }
                         self.add_bind_pattern(pat, gv, t)?;
@@ -682,7 +677,7 @@ impl Context {
                     Ok((Arc::new(Value::None), unit!()))
                 }
             }
-Expr::Assign(assignee, body) => {
+            Expr::Assign(assignee, body) => {
                 let (src, ty) = self.eval_expr(*body)?;
                 let dst = self.eval_var(*assignee, ty, &span)?;
                 Ok((self.push_inst(Instruction::Store(dst, src, ty)), ty))
@@ -715,8 +710,6 @@ Expr::Assign(assignee, body) => {
             Expr::Bracket(_) => todo!(),
             Expr::Escape(_) => todo!(),
             Expr::Error => todo!(),
-            Expr::Assign(_, _) => todo!(),
-            Expr::Then(_, _) => todo!(),
         }
     }
 }

--- a/mimium-lang/src/compiler/mirgen.rs
+++ b/mimium-lang/src/compiler/mirgen.rs
@@ -428,7 +428,7 @@ impl Context {
                 let t = InferContext::infer_type_literal(lit).map_err(CompileError::from)?;
                 Ok((v, t))
             }
-            Expr::Var(name, _time) => Ok((self.eval_var(*name, ty, &span)?, ty)),
+            Expr::Var(name) => Ok((self.eval_var(*name, ty, &span)?, ty)),
             Expr::Block(b) => {
                 if let Some(block) = b {
                     self.eval_expr(*block)

--- a/mimium-lang/src/compiler/mirgen.rs
+++ b/mimium-lang/src/compiler/mirgen.rs
@@ -682,6 +682,18 @@ impl Context {
                     Ok((Arc::new(Value::None), unit!()))
                 }
             }
+Expr::Assign(assignee, body) => {
+                let (src, ty) = self.eval_expr(*body)?;
+                let dst = self.eval_var(*assignee, ty, &span)?;
+                Ok((self.push_inst(Instruction::Store(dst, src, ty)), ty))
+            }
+            Expr::Then(body, then) => {
+                let _ = self.eval_expr(*body)?;
+                match then {
+                    Some(t) => self.eval_expr(*t),
+                    None => Ok((Arc::new(Value::None), unit!())),
+                }
+            }
             Expr::If(cond, then, else_) => {
                 let (c, _) = self.eval_expr(*cond)?;
                 let bbidx = self.get_ctxdata().current_bb;

--- a/mimium-lang/src/compiler/mirgen/recursecheck.rs
+++ b/mimium-lang/src/compiler/mirgen/recursecheck.rs
@@ -7,7 +7,7 @@ use crate::{
 
 fn try_find_recurse(e_s: ExprNodeId, name: &Symbol) -> bool {
     match &e_s.to_expr() {
-        Expr::Var(n, _) => n == name,
+        Expr::Var(n) => n == name,
         Expr::Let(_id, body, then) => {
             try_find_recurse(*body, name) || then.map_or(false, |e| try_find_recurse(e, name))
         }

--- a/mimium-lang/src/compiler/mirgen/selfconvert.rs
+++ b/mimium-lang/src/compiler/mirgen/selfconvert.rs
@@ -59,7 +59,7 @@ fn convert_self(e_id: ExprNodeId, feedctx: FeedId) -> Result<ConvertResult, Erro
         Expr::Literal(Literal::SelfLit) => match feedctx {
             FeedId::Global => Err(Error::NoParentSelf(span.clone())),
             FeedId::Local(i) => Ok(ConvertResult::Err(
-                Expr::Var(get_feedvar_name(i), None).into_id(span.clone()),
+                Expr::Var(get_feedvar_name(i)).into_id(span.clone()),
             )),
         },
         Expr::Tuple(v) => {
@@ -201,7 +201,7 @@ mod test {
                 None,
                 Expr::Feed(
                     "feed_id0".to_symbol(),
-                    Expr::Var("feed_id0".to_symbol(), None).into_id(0..1),
+                    Expr::Var("feed_id0".to_symbol()).into_id(0..1),
                 )
                 .into_id(0..1),
             )

--- a/mimium-lang/src/compiler/parser.rs
+++ b/mimium-lang/src/compiler/parser.rs
@@ -108,7 +108,106 @@ fn pattern_parser() -> impl Parser<Token, TypedPattern, Error = Simple<Token>> +
         },
     })
 }
+fn op_parser<'a, I>(apply: I) -> impl Parser<Token, ExprNodeId, Error = Simple<Token>> + Clone + 'a
+where
+    I: Parser<Token, ExprNodeId, Error = Simple<Token>> + Clone + 'a,
+{
+    let unary = select! { Token::Op(Op::Minus) => {} }
+        .map_with_span(|e, s| (e, s))
+        .repeated()
+        .then(apply)
+        .foldr(|(_op, op_span), rhs| {
+            let rhs_span = rhs.to_span();
+            let neg_op = Expr::Var("neg".to_symbol()).into_id(op_span.start..rhs_span.start);
+            Expr::Apply(neg_op, vec![rhs]).into_id(op_span.start..rhs_span.end)
+        })
+        .labelled("unary");
 
+    let op_cls = |x: ExprNodeId, y: ExprNodeId, op: Op, opspan: Span| {
+        Expr::Apply(
+            Expr::Var(op.get_associated_fn_name()).into_id(opspan),
+            vec![x, y],
+        )
+        .into_id(x.to_span().start..y.to_span().end)
+    };
+    let optoken = move |o: Op| {
+        just(Token::Op(o)).map_with_span(|e, s| {
+            (
+                match e {
+                    Token::Op(o) => o,
+                    _ => Op::Unknown(String::from("invalid")),
+                },
+                s,
+            )
+        })
+    };
+
+    let op = optoken(Op::Exponent);
+    let exponent = unary
+        .clone()
+        .then(op.then(unary).repeated())
+        .foldl(move |x, ((op, opspan), y)| op_cls(x, y, op, opspan))
+        .boxed();
+    let op = choice((
+        optoken(Op::Product),
+        optoken(Op::Divide),
+        optoken(Op::Modulo),
+    ));
+    let product = exponent
+        .clone()
+        .then(op.then(exponent).repeated())
+        .foldl(move |x, ((op, opspan), y)| op_cls(x, y, op, opspan))
+        .boxed();
+    let op = optoken(Op::Sum).or(optoken(Op::Minus));
+    let add = product
+        .clone()
+        .then(op.then(product).repeated())
+        .foldl(move |x, ((op, opspan), y)| op_cls(x, y, op, opspan))
+        .boxed();
+
+    let op = optoken(Op::Equal).or(optoken(Op::NotEqual));
+
+    let cmp = add
+        .clone()
+        .then(op.then(add).repeated())
+        .foldl(move |x, ((op, opspan), y)| op_cls(x, y, op, opspan))
+        .boxed();
+    let op = optoken(Op::And);
+    let cmp = cmp
+        .clone()
+        .then(op.then(cmp).repeated())
+        .foldl(move |x, ((op, opspan), y)| op_cls(x, y, op, opspan))
+        .boxed();
+    let op = optoken(Op::Or);
+    let cmp = cmp
+        .clone()
+        .then(op.then(cmp).repeated())
+        .foldl(move |x, ((op, opspan), y)| op_cls(x, y, op, opspan))
+        .boxed();
+    let op = choice((
+        optoken(Op::LessThan),
+        optoken(Op::LessEqual),
+        optoken(Op::GreaterThan),
+        optoken(Op::GreaterEqual),
+    ));
+    let cmp = cmp
+        .clone()
+        .then(op.then(cmp).repeated())
+        .foldl(move |x, ((op, opspan), y)| op_cls(x, y, op, opspan))
+        .boxed();
+    let op = optoken(Op::Pipe);
+
+    let pipe = cmp
+        .clone()
+        .then(op.then(cmp).repeated())
+        .foldl(|lhs, ((_, _), rhs)| {
+            let span = lhs.to_span().start..rhs.to_span().end;
+            Expr::Apply(rhs, vec![lhs]).into_id(span)
+        })
+        .boxed();
+
+    pipe
+}
 fn expr_parser() -> impl Parser<Token, ExprNodeId, Error = Simple<Token>> + Clone {
     let lvar = lvar_parser_typed();
     let pattern = pattern_parser();
@@ -191,102 +290,7 @@ fn expr_parser() -> impl Parser<Token, ExprNodeId, Error = Simple<Token>> + Clon
             };
             let apply = atom.then(parenitems).foldl(folder).labelled("apply");
 
-            let unary = select! { Token::Op(Op::Minus) => {} }
-                .map_with_span(|e, s| (e, s))
-                .repeated()
-                .then(apply)
-                .foldr(|(_op, op_span), rhs| {
-                    let rhs_span = rhs.to_span();
-                    let neg_op =
-                        Expr::Var("neg".to_symbol()).into_id(op_span.start..rhs_span.start);
-                    Expr::Apply(neg_op, vec![rhs]).into_id(op_span.start..rhs_span.end)
-                })
-                .labelled("unary");
-
-            let op_cls = |x: ExprNodeId, y: ExprNodeId, op: Op, opspan: Span| {
-                Expr::Apply(
-                    Expr::Var(op.get_associated_fn_name()).into_id(opspan),
-                    vec![x, y],
-                )
-                .into_id(x.to_span().start..y.to_span().end)
-            };
-            let optoken = move |o: Op| {
-                just(Token::Op(o)).map_with_span(|e, s| {
-                    (
-                        match e {
-                            Token::Op(o) => o,
-                            _ => Op::Unknown(String::from("invalid")),
-                        },
-                        s,
-                    )
-                })
-            };
-
-            let op = optoken(Op::Exponent);
-            let exponent = unary
-                .clone()
-                .then(op.then(unary).repeated())
-                .foldl(move |x, ((op, opspan), y)| op_cls(x, y, op, opspan))
-                .boxed();
-            let op = choice((
-                optoken(Op::Product),
-                optoken(Op::Divide),
-                optoken(Op::Modulo),
-            ));
-            let product = exponent
-                .clone()
-                .then(op.then(exponent).repeated())
-                .foldl(move |x, ((op, opspan), y)| op_cls(x, y, op, opspan))
-                .boxed();
-            let op = optoken(Op::Sum).or(optoken(Op::Minus));
-            let add = product
-                .clone()
-                .then(op.then(product).repeated())
-                .foldl(move |x, ((op, opspan), y)| op_cls(x, y, op, opspan))
-                .boxed();
-
-            let op = optoken(Op::Equal).or(optoken(Op::NotEqual));
-
-            let cmp = add
-                .clone()
-                .then(op.then(add).repeated())
-                .foldl(move |x, ((op, opspan), y)| op_cls(x, y, op, opspan))
-                .boxed();
-            let op = optoken(Op::And);
-            let cmp = cmp
-                .clone()
-                .then(op.then(cmp).repeated())
-                .foldl(move |x, ((op, opspan), y)| op_cls(x, y, op, opspan))
-                .boxed();
-            let op = optoken(Op::Or);
-            let cmp = cmp
-                .clone()
-                .then(op.then(cmp).repeated())
-                .foldl(move |x, ((op, opspan), y)| op_cls(x, y, op, opspan))
-                .boxed();
-            let op = choice((
-                optoken(Op::LessThan),
-                optoken(Op::LessEqual),
-                optoken(Op::GreaterThan),
-                optoken(Op::GreaterEqual),
-            ));
-            let cmp = cmp
-                .clone()
-                .then(op.then(cmp).repeated())
-                .foldl(move |x, ((op, opspan), y)| op_cls(x, y, op, opspan))
-                .boxed();
-            let op = optoken(Op::Pipe);
-
-            let pipe = cmp
-                .clone()
-                .then(op.then(cmp).repeated())
-                .foldl(|lhs, ((_, _), rhs)| {
-                    let span = lhs.to_span().start..rhs.to_span().end;
-                    Expr::Apply(rhs, vec![lhs]).into_id(span)
-                })
-                .boxed();
-
-            pipe
+            op_parser(apply)
         });
         // expr_group contains let statement, assignment statement, function definiton,... they cannot be placed as an argument for apply directly.
 

--- a/mimium-lang/src/compiler/parser/test.rs
+++ b/mimium-lang/src/compiler/parser/test.rs
@@ -8,7 +8,7 @@ macro_rules! test_string {
         let srcstr = $src.to_string();
         match parse(&srcstr) {
             Ok(ast) => {
-                assert_eq!(ast, $ans);
+                assert_eq!(ast.to_expr(), $ans.to_expr());
             }
             Err(errs) => {
                 utils::error::report(&srcstr, PathBuf::new(), &errs);
@@ -229,7 +229,7 @@ fn test_tuple() {
     test_string!("(1.0, 2.0, )", ans);
 
     // trailing comma is mandatory for a single-element tuple
-    let ans = Expr::Tuple(vec![tuple_items[0].clone()]).into_id(0..7);
+    let ans = Expr::Tuple(vec![tuple_items[0]]).into_id(0..7);
     test_string!("(1.0, )", ans);
 
     // This is not a tuple

--- a/mimium-lang/src/compiler/parser/test.rs
+++ b/mimium-lang/src/compiler/parser/test.rs
@@ -128,6 +128,33 @@ fn test_apply() {
     .into_id(0..13);
     test_string!("myfun(callee)", ans);
 }
+
+#[test]
+fn test_assign1() {
+    let ans = Expr::Then(
+        Expr::Assign(
+            "hoge".to_symbol(),
+            Expr::Var("fuga".to_symbol()).into_id(6..10),
+        )
+        .into_id(0..10),
+        None,
+    )
+    .into_id(0..10);
+    test_string!("hoge = fuga", ans);
+}
+#[test]
+fn test_assign2() {
+    let ans = Expr::Then(
+        Expr::Assign(
+            "hoge".to_symbol(),
+            Expr::Var("fuga".to_symbol()).into_id(6..10),
+        )
+        .into_id(0..10),
+        Some(Expr::Literal(Literal::Float("100.0".to_string())).into_id(13..18)),
+    )
+    .into_id(0..10);
+    test_string!("hoge = fuga\n 100.0", ans);
+}
 #[test]
 fn test_applynested() {
     let ans = Expr::Apply(

--- a/mimium-lang/src/compiler/parser/test.rs
+++ b/mimium-lang/src/compiler/parser/test.rs
@@ -26,7 +26,7 @@ fn test_let() {
             ty: Type::Unknown.into_id_with_span(4..8),
         },
         Expr::Literal(Literal::Int(36)).into_id(11..13),
-        Some(Expr::Var("goge".to_symbol(), None).into_id(15..19)),
+        Some(Expr::Var("goge".to_symbol()).into_id(15..19)),
     )
     .into_id(0..19);
     test_string!("let goge = 36\n goge", ans);
@@ -46,7 +46,7 @@ fn test_lettuple() {
             Expr::Literal(Literal::Int(89)).into_id(16..18),
         ])
         .into_id(12..19),
-        Some(Expr::Var("hoge".to_symbol(), None).into_id(21..25)),
+        Some(Expr::Var("hoge".to_symbol()).into_id(21..25)),
     )
     .into_id(0..25);
     test_string!("let (a,b) = (36,89)\n hoge", ans);
@@ -55,8 +55,8 @@ fn test_lettuple() {
 fn test_if() {
     let ans = Expr::If(
         Expr::Literal(Literal::Int(100)).into_id(4..7),
-        Expr::Var("hoge".to_symbol(), None).into_id(9..13),
-        Some(Expr::Var("fuga".to_symbol(), None).into_id(19..23)),
+        Expr::Var("hoge".to_symbol()).into_id(9..13),
+        Some(Expr::Var("fuga".to_symbol()).into_id(19..23)),
     )
     .into_id(0..23);
     test_string!("if (100) hoge else fuga", ans);
@@ -65,7 +65,7 @@ fn test_if() {
 fn test_if_noelse() {
     let ans = Expr::If(
         Expr::Literal(Literal::Int(100)).into_id(4..7),
-        Expr::Var("hoge".to_symbol(), None).into_id(9..13),
+        Expr::Var("hoge".to_symbol()).into_id(9..13),
         None,
     )
     .into_id(0..13);
@@ -91,7 +91,7 @@ fn test_block() {
                 ty: Type::Unknown.into_id_with_span(5..9),
             },
             Expr::Literal(Literal::Int(100)).into_id(12..15),
-            Some(Expr::Var("hoge".to_symbol(), None).into_id(16..20)),
+            Some(Expr::Var("hoge".to_symbol()).into_id(16..20)),
         )
         .into_id(1..20),
     ))
@@ -105,7 +105,7 @@ hoge}",
 #[test]
 fn test_add() {
     let ans = Expr::Apply(
-        Expr::Var("add".to_symbol(), None).into_id(6..7),
+        Expr::Var("add".to_symbol()).into_id(6..7),
         vec![
             Expr::Literal(Literal::Float("3466.0".to_string())).into_id(0..6),
             Expr::Literal(Literal::Float("2000.0".to_string())).into_id(7..13),
@@ -116,14 +116,14 @@ fn test_add() {
 }
 #[test]
 fn test_var() {
-    let ans = Expr::Var("hoge".to_symbol(), None).into_id(0..4);
+    let ans = Expr::Var("hoge".to_symbol()).into_id(0..4);
     test_string!("hoge", ans);
 }
 #[test]
 fn test_apply() {
     let ans = Expr::Apply(
-        Expr::Var("myfun".to_symbol(), None).into_id(0..5),
-        vec![Expr::Var("callee".to_symbol(), None).into_id(6..12)],
+        Expr::Var("myfun".to_symbol()).into_id(0..5),
+        vec![Expr::Var("callee".to_symbol()).into_id(6..12)],
     )
     .into_id(0..13);
     test_string!("myfun(callee)", ans);
@@ -131,10 +131,10 @@ fn test_apply() {
 #[test]
 fn test_applynested() {
     let ans = Expr::Apply(
-        Expr::Var("myfun".to_symbol(), None).into_id(0..5),
+        Expr::Var("myfun".to_symbol()).into_id(0..5),
         vec![Expr::Apply(
-            Expr::Var("myfun2".to_symbol(), None).into_id(6..12),
-            vec![Expr::Var("callee".to_symbol(), None).into_id(13..19)],
+            Expr::Var("myfun2".to_symbol()).into_id(6..12),
+            vec![Expr::Var("callee".to_symbol()).into_id(13..19)],
         )
         .into_id(6..20)],
     )
@@ -145,8 +145,8 @@ fn test_applynested() {
 fn test_macroexpand() {
     let ans = Expr::Escape(
         Expr::Apply(
-            Expr::Var("myfun".to_symbol(), None).into_id(0..6),
-            vec![Expr::Var("callee".to_symbol(), None).into_id(7..13)],
+            Expr::Var("myfun".to_symbol()).into_id(0..6),
+            vec![Expr::Var("callee".to_symbol()).into_id(7..13)],
         )
         .into_id(0..14),
     )
@@ -178,7 +178,7 @@ fn test_fndef() {
                 },
             ],
             None,
-            Expr::Var("input".to_symbol(), None).into_id(21..26),
+            Expr::Var("input".to_symbol()).into_id(21..26),
         )
         .into_id(0..28),
         None,
@@ -205,7 +205,7 @@ fn test_macrodef() {
                 },
             ],
             None,
-            Expr::Bracket(Expr::Var("input".to_symbol(), None).into_id(24..29)).into_id(24..29),
+            Expr::Bracket(Expr::Var("input".to_symbol()).into_id(24..29)).into_id(24..29),
         )
         .into_id(0..31),
         None,

--- a/mimium-lang/src/compiler/typing.rs
+++ b/mimium-lang/src/compiler/typing.rs
@@ -451,7 +451,7 @@ impl InferContext {
                 };
                 res
             }
-            Expr::Var(name, _time) => self.lookup(name, &span),
+            Expr::Var(name) => self.lookup(name, &span),
             Expr::Apply(fun, callee) => {
                 let fnl = self.infer_type(*fun)?;
                 let callee_t = self.infer_vec(callee.as_slice())?;

--- a/mimium-lang/src/compiler/typing.rs
+++ b/mimium-lang/src/compiler/typing.rs
@@ -448,8 +448,15 @@ impl InferContext {
                 let res = match then {
                     Some(e) => self.infer_type(*e),
                     None => Ok(Type::Primitive(PType::Unit).into_id()),
-                };
-                res
+            Expr::Assign(name, expr) => {
+                let assignee_t = self.lookup(name, &span)?;
+                let e_t = self.infer_type(*expr)?;
+                self.unify_types(assignee_t, e_t)?;
+                Ok(unit!())
+            }
+            Expr::Then(e, then) => {
+                let _ = self.infer_type(*e)?;
+                then.map_or(Ok(unit!()), |t| self.infer_type(t))
             }
             Expr::Var(name) => self.lookup(name, &span),
             Expr::Apply(fun, callee) => {

--- a/mimium-lang/src/compiler/typing.rs
+++ b/mimium-lang/src/compiler/typing.rs
@@ -5,9 +5,9 @@ use crate::pattern::{Pattern, TypedPattern};
 use crate::runtime::vm::builtin;
 use crate::types::{PType, Type, TypeVar};
 use crate::utils::{environment::Environment, error::ReportableError, metadata::Span};
-use crate::{function, numeric};
+use crate::{function, numeric, unit};
 use std::cell::RefCell;
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 use std::fmt;
 use std::rc::Rc;
 
@@ -130,25 +130,25 @@ impl InferContext {
             .collect::<Vec<_>>();
         env.add_bind(&binds);
     }
-    pub fn gen_intermediate_type(&mut self) -> TypeNodeId {
+    fn gen_intermediate_type(&mut self) -> TypeNodeId {
         let res =
             Type::Intermediate(Rc::new(RefCell::new(TypeVar::new(self.interm_idx)))).into_id();
         self.interm_idx += 1;
         res
     }
-    pub fn gen_intermediate_type_with_span(&mut self, span: Span) -> TypeNodeId {
+    fn gen_intermediate_type_with_span(&mut self, span: Span) -> TypeNodeId {
         let res = Type::Intermediate(Rc::new(RefCell::new(TypeVar::new(self.interm_idx))))
             .into_id_with_span(span);
         self.interm_idx += 1;
         res
     }
-    pub fn convert_unknown_to_intermediate(&mut self, t: TypeNodeId) -> TypeNodeId {
+    fn convert_unknown_to_intermediate(&mut self, t: TypeNodeId) -> TypeNodeId {
         match t.to_type() {
             Type::Unknown => self.gen_intermediate_type(),
             _ => t,
         }
     }
-    pub fn convert_unknown_function(
+    fn convert_unknown_function(
         &mut self,
         atypes: &[TypeNodeId],
         rty: TypeNodeId,
@@ -162,8 +162,8 @@ impl InferContext {
         Type::Function(a, r, s).into_id()
     }
     // return true when the circular loop of intermediate variable exists.
-    pub fn occur_check(&self, id1: u64, t2: TypeNodeId) -> bool {
-        let cls = |t2dash: TypeNodeId| -> bool { self.occur_check(id1, t2dash) };
+    fn occur_check(id1: u64, t2: TypeNodeId) -> bool {
+        let cls = |t2dash: TypeNodeId| -> bool { Self::occur_check(id1, t2dash) };
 
         let vec_cls = |t: &[_]| -> bool { t.iter().any(|a| cls(*a)) };
 
@@ -171,7 +171,7 @@ impl InferContext {
             Type::Intermediate(cell) => cell
                 .try_borrow()
                 .map(|tv2| match tv2.parent {
-                    Some(tid2) => id1 == tv2.var || self.occur_check(id1, tid2),
+                    Some(tid2) => id1 == tv2.var || Self::occur_check(id1, tid2),
                     None => id1 == tv2.var,
                 })
                 .unwrap_or(true),
@@ -187,32 +187,23 @@ impl InferContext {
         }
     }
 
-    // fn substitute_intermediate_type(&self, id: i64) -> TypeNodeId {
-    //     match self.subst_map.get(&id) {
-    //         Some(t) => match t.to_type() {
-    //             Type::Intermediate(tv) => self.substitute_intermediate_type(i),
-    //             _ => *t,
-    //         },
-    //         None => None,
-    //     }
-    // }
-    fn substitute_type(&self, t: TypeNodeId) -> TypeNodeId {
+    fn substitute_type(t: TypeNodeId) -> TypeNodeId {
         match t.to_type() {
             Type::Intermediate(cell) => {
                 let TypeVar { parent, var: _ } = &cell.borrow() as &TypeVar;
                 match parent {
-                    Some(p) => self.substitute_type(*p),
+                    Some(p) => Self::substitute_type(*p),
                     None => t,
                 }
             }
-            _ => t.apply_fn(|ty| self.substitute_type(ty)),
+            _ => t.apply_fn(Self::substitute_type),
         }
     }
     fn substitute_all_intermediates(&mut self) {
         let mut e_list = self
             .result_map
             .iter()
-            .map(|(e, t)| (*e, self.substitute_type(*t)))
+            .map(|(e, t)| (*e, Self::substitute_type(*t)))
             .collect::<Vec<_>>();
 
         e_list.iter_mut().for_each(|(e, t)| {
@@ -221,8 +212,8 @@ impl InferContext {
         })
     }
 
-    pub fn unify_types(&mut self, t1: TypeNodeId, t2: TypeNodeId) -> Result<TypeNodeId, Error> {
-        let mut unify_vec = |a1: &[TypeNodeId], a2: &[TypeNodeId]| -> Result<Vec<_>, Error> {
+    fn unify_types(t1: TypeNodeId, t2: TypeNodeId) -> Result<TypeNodeId, Error> {
+        let unify_vec = |a1: &[TypeNodeId], a2: &[TypeNodeId]| -> Result<Vec<_>, Error> {
             if a1.len() != a2.len() {
                 return Err(Error(
                     ErrorKind::TypeMismatch(t1.to_type(), t2.to_type()),
@@ -232,7 +223,7 @@ impl InferContext {
 
             a1.iter()
                 .zip(a2.iter())
-                .map(|(v1, v2)| self.unify_types(*v1, *v2))
+                .map(|(v1, v2)| Self::unify_types(*v1, *v2))
                 .try_collect()
         };
         log::trace!("unify {} and {}", t1.to_type(), t2.to_type());
@@ -241,7 +232,7 @@ impl InferContext {
         match &(t1r.to_type(), t2r.to_type()) {
             (Type::Intermediate(i1), Type::Intermediate(i2)) => {
                 let tv1 = &mut i1.borrow_mut() as &mut TypeVar;
-                if self.occur_check(tv1.var, t2) {
+                if Self::occur_check(tv1.var, t2) {
                     return Ok(t1r);
                 }
                 let tv2 = &mut i2.borrow_mut() as &mut TypeVar;
@@ -276,16 +267,16 @@ impl InferContext {
                 Ok(t1r)
             }
             (Type::Array(a1), Type::Array(a2)) => {
-                Ok(Type::Array(self.unify_types(*a1, *a2)?).into_id())
+                Ok(Type::Array(Self::unify_types(*a1, *a2)?).into_id())
             }
-            (Type::Ref(x1), Type::Ref(x2)) => Ok(Type::Ref(self.unify_types(*x1, *x2)?).into_id()),
+            (Type::Ref(x1), Type::Ref(x2)) => Ok(Type::Ref(Self::unify_types(*x1, *x2)?).into_id()),
             (Type::Tuple(a1), Type::Tuple(a2)) => Ok(Type::Tuple(unify_vec(a1, a2)?).into_id()),
             (Type::Struct(_a1), Type::Struct(_a2)) => todo!(), //todo
             (Type::Function(p1, r1, s1), Type::Function(p2, r2, s2)) => Ok(Type::Function(
                 unify_vec(p1, p2)?,
-                self.unify_types(*r1, *r2)?,
+                Self::unify_types(*r1, *r2)?,
                 match (s1, s2) {
-                    (Some(e1), Some(e2)) => Some(self.unify_types(*e1, *e2)?),
+                    (Some(e1), Some(e2)) => Some(Self::unify_types(*e1, *e2)?),
                     (None, None) => None,
                     (_, _) => todo!("error handling"),
                 },
@@ -301,11 +292,7 @@ impl InferContext {
             (p1, p2) => Err(Error(ErrorKind::TypeMismatch(p1.clone(), p2.clone()), 0..0)), //todo:span
         }
     }
-    pub fn bind_pattern(
-        &mut self,
-        t: TypeNodeId,
-        ty_pat: &TypedPattern,
-    ) -> Result<TypeNodeId, Error> {
+    fn bind_pattern(&mut self, t: TypeNodeId, ty_pat: &TypedPattern) -> Result<TypeNodeId, Error> {
         let TypedPattern { pat, .. } = ty_pat;
         let span = ty_pat.to_span();
         let pat_t = match pat {
@@ -328,7 +315,7 @@ impl InferContext {
                 Ok(Type::Tuple(res).into_id())
             }
         }?;
-        self.unify_types(t, pat_t)
+        Self::unify_types(t, pat_t)
     }
 
     pub fn lookup(&self, name: &Symbol, span: &Span) -> Result<TypeNodeId, Error> {
@@ -380,7 +367,7 @@ impl InferContext {
                 let feedv = self.gen_intermediate_type();
                 self.env.add_bind(&[(*id, feedv)]);
                 let b = self.infer_type(*body)?;
-                let res = self.unify_types(b, feedv)?;
+                let res = Self::unify_types(b, feedv)?;
                 if res.to_type().contains_function() {
                     Err(Error(ErrorKind::NonPrimitiveInFeed, body.to_span().clone()))
                 } else {
@@ -403,7 +390,7 @@ impl InferContext {
                     .collect();
                 let bty = if let Some(r) = rtype {
                     let bty = self.infer_type(*body)?;
-                    self.unify_types(*r, bty)?
+                    Self::unify_types(*r, bty)?
                 } else {
                     self.infer_type(*body)?
                 };
@@ -423,14 +410,13 @@ impl InferContext {
                     self.gen_intermediate_type()
                 };
 
-                let bodyt_u = self.unify_types(idt, bodyt)?;
+                let bodyt_u = Self::unify_types(idt, bodyt)?;
                 let _ = self.bind_pattern(bodyt_u, tpat)?;
 
-                let res = match then {
+                match then {
                     Some(e) => self.infer_type(*e),
                     None => Ok(Type::Primitive(PType::Unit).into_id()),
-                };
-                res
+                }
             }
             Expr::LetRec(id, body, then) => {
                 let idt = match (id.is_unknown(), id.ty.to_type()) {
@@ -443,15 +429,17 @@ impl InferContext {
                 let body_i = self.gen_intermediate_type();
                 self.env.add_bind(&[(id.id, body_i)]);
                 let bodyt = self.infer_type(*body)?;
-                let _ = self.unify_types(idt, bodyt)?;
+                let _ = Self::unify_types(idt, bodyt)?;
 
-                let res = match then {
+                match then {
                     Some(e) => self.infer_type(*e),
                     None => Ok(Type::Primitive(PType::Unit).into_id()),
+                }
+            }
             Expr::Assign(name, expr) => {
                 let assignee_t = self.lookup(name, &span)?;
                 let e_t = self.infer_type(*expr)?;
-                self.unify_types(assignee_t, e_t)?;
+                Self::unify_types(assignee_t, e_t)?;
                 Ok(unit!())
             }
             Expr::Then(e, then) => {
@@ -464,7 +452,7 @@ impl InferContext {
                 let callee_t = self.infer_vec(callee.as_slice())?;
                 let res_t = self.gen_intermediate_type();
                 let fntype = Type::Function(callee_t, res_t, None).into_id();
-                let restype = self.unify_types(fnl, fntype)?;
+                let restype = Self::unify_types(fnl, fntype)?;
                 if let Type::Function(_, r, _) = restype.to_type() {
                     Ok(r)
                 } else {
@@ -476,12 +464,12 @@ impl InferContext {
             }
             Expr::If(cond, then, opt_else) => {
                 let condt = self.infer_type(*cond)?;
-                let _bt = self.unify_types(Type::Primitive(PType::Numeric).into_id(), condt); //todo:boolean type
+                let _bt = Self::unify_types(Type::Primitive(PType::Numeric).into_id(), condt); //todo:boolean type
                 let thent = self.infer_type(*then)?;
                 let elset = opt_else.map_or(Ok(Type::Primitive(PType::Unit).into_id()), |e| {
                     self.infer_type(e)
                 })?;
-                self.unify_types(thent, elset)
+                Self::unify_types(thent, elset)
             }
             Expr::Block(expr) => expr.map_or(Ok(Type::Primitive(PType::Unit).into_id()), |e| {
                 self.infer_type(e)
@@ -491,9 +479,8 @@ impl InferContext {
                 Ok(Type::Primitive(PType::Unit).into_id())
             }
         };
-        res.map(|ty| {
-            self.result_map.insert(e.0, ty);
-            ty
+        res.inspect(|ty| {
+            self.result_map.insert(e.0, *ty);
         })
     }
     pub fn lookup_res(&self, e: ExprNodeId) -> TypeNodeId {

--- a/mimium-lang/src/mir.rs
+++ b/mimium-lang/src/mir.rs
@@ -26,7 +26,7 @@ pub enum Value {
     ExtFunction(Symbol, TypeNodeId),
     FixPoint(usize), //function id
     //internal state
-    None, //??
+    None,
 }
 
 pub type VPtr = Arc<Value>;

--- a/mimium-lang/src/mir.rs
+++ b/mimium-lang/src/mir.rs
@@ -176,6 +176,15 @@ impl Function {
         self.body.push(Block(vec![]));
         self.body.len() - 1
     }
+    pub fn get_or_insert_upvalue(&mut self, v: &Arc<Value>) -> usize {
+        self.upindexes
+            .iter()
+            .position(|vt| v == vt)
+            .unwrap_or_else(|| {
+                self.upindexes.push(v.clone());
+                self.upindexes.len() - 1
+            })
+    }
 }
 
 #[derive(Debug, Clone, Default)]

--- a/mimium-lang/src/mir.rs
+++ b/mimium-lang/src/mir.rs
@@ -41,7 +41,7 @@ pub enum Instruction {
     Alloc(TypeNodeId),
     // load value to register from the pointer type
     Load(VPtr, TypeNodeId),
-    // store value to pointer
+    // Store value to stack(destination,source, type)
     Store(VPtr, VPtr, TypeNodeId),
     // Instruction for computing destination address like LLVM's GetElementPtr.
     // This instruction does no actual computation on runtime.
@@ -62,7 +62,7 @@ pub enum Instruction {
     CloseUpValue(VPtr),
     //label to funcproto  and localvar offset?
     GetUpValue(u64, TypeNodeId),
-    SetUpValue(u64, TypeNodeId),
+    SetUpValue(u64, VPtr, TypeNodeId),
     //internal state: feed and delay
     PushStateOffset(Vec<StateSize>),
     PopStateOffset(Vec<StateSize>),

--- a/mimium-lang/src/mir/print.rs
+++ b/mimium-lang/src/mir/print.rs
@@ -130,7 +130,9 @@ impl std::fmt::Display for Instruction {
                 write!(f, "close {}", *cls)
             }
             Instruction::GetUpValue(idx, ty) => write!(f, "getupval {idx} {}", ty.to_type()),
-            Instruction::SetUpValue(idx, ty) => write!(f, "setupval {idx} {}", ty.to_type()),
+            Instruction::SetUpValue(dst, src, ty) => {
+                write!(f, "setupval {dst} {} {}", src, ty.to_type())
+            }
             Instruction::GetGlobal(v, ty) => write!(f, "getglobal {} {}", *v, ty.to_type()),
             Instruction::SetGlobal(dst, src, ty) => {
                 write!(f, "setglobal {} {} {}", *dst, *src, ty.to_type())

--- a/mimium-lang/tests/intergration_test.rs
+++ b/mimium-lang/tests/intergration_test.rs
@@ -235,6 +235,12 @@ fn stateful_closure() {
     ];
     assert_eq!(res, ans);
 }
+#[test]
+fn closure_counter() {
+    let res = run_file_test_mono("closure_counter.mmm", 5).unwrap();
+    let ans = vec![0.0, 1.0, 2.0, 3.0, 4.0];
+    assert_eq!(res, ans);
+}
 
 #[test]
 fn hof_state() {

--- a/mimium-lang/tests/mmm/closure_counter.mmm
+++ b/mimium-lang/tests/mmm/closure_counter.mmm
@@ -2,8 +2,9 @@
 fn makecounter(){
     let x = 0.0
     let countup = | |{
+        let res = x
         x = x+1.0
-        x
+        res 
     }
     countup
 }

--- a/mimium-lang/tests/mmm/closure_counter.mmm
+++ b/mimium-lang/tests/mmm/closure_counter.mmm
@@ -12,4 +12,3 @@ let myc = makecounter();
 fn dsp(){
     myc()
 }
-

--- a/mimium-lang/tests/mmm/closure_counter.mmm
+++ b/mimium-lang/tests/mmm/closure_counter.mmm
@@ -1,0 +1,14 @@
+// counter implemented using closure. for the test of assignment expression
+fn makecounter(){
+    let x = 0.0
+    let countup = | |{
+        x = x+1.0
+        x
+    }
+    countup
+}
+let myc = makecounter();
+fn dsp(){
+    myc()
+}
+

--- a/mimium-lang/tests/mmm/closure_counter2.mmm
+++ b/mimium-lang/tests/mmm/closure_counter2.mmm
@@ -1,0 +1,18 @@
+//deeply nested closure with destructive assignment
+fn makemakecounter(){
+    let makecounter = | |{
+        let x = 0.0
+        let countup = | |{
+            let res = x
+            x = x+1.0
+            res 
+        }
+        countup
+    }
+    makecounter
+}
+let mymc = makemakecounter();
+let myc = mymc();
+fn dsp(){
+    myc()
+}


### PR DESCRIPTION
This PR implements destructive assignment expression.

With this implementation, stateful object with closure can be expressed like below.

```rust
fn makecounter(){
    let x = 0.0
    let countup = | |{
        let res = x
        x = x+1.0
        res 
    }
    countup
}
let myc = makecounter();
fn dsp(){
    myc()
}
```

This PR also contains some parser refactoring previously attempted in #23.
