### PR TITLE
Test on state sizes instead of running 100 times

### DIFF
--- a/mimium-lang/tests/intergration_test.rs
+++ b/mimium-lang/tests/intergration_test.rs
@@ -323,6 +323,11 @@ fn test_state_sizes<T: IntoIterator<Item = (&'static str, u64)>>(path: &str, ans
 
     for (sym, proto) in bytecode.global_fn_table {
         let fn_name = sym.as_str();
+
+        if fn_name == "_mimium_global" {
+            continue;
+        }
+
         let actual = proto.state_size;
         match state_sizes.get(fn_name) {
             Some(&expected) => {
@@ -340,11 +345,6 @@ fn test_state_sizes<T: IntoIterator<Item = (&'static str, u64)>>(path: &str, ans
 fn fb_mem3_state_size() {
     test_state_sizes(
         "fb_mem3.mmm",
-        [
-            ("_mimium_global", 0),
-            ("counter", 1),
-            ("mem_by_hand", 4),
-            ("dsp", 5),
-        ],
+        [("counter", 1), ("mem_by_hand", 4), ("dsp", 5)],
     );
 }


### PR DESCRIPTION
I added a test in https://github.com/tomoyanonymous/mimium-rs/pull/34 to check the calculation of state sizes, but it's not very nice because it relies on random symptom. This pull request replace the test with one that checks the actual state sizes. 

Probably we should add more test cases here, but I think this one should be suffice for now.