### PR TITLE
Implement syntactic sugar `now`

### DIFF
--- a/mimium-audiodriver/src/backends/cpal.rs
+++ b/mimium-audiodriver/src/backends/cpal.rs
@@ -77,8 +77,6 @@ impl NativeAudioData {
             let _rc = self.vmdata.vm.execute_idx(&self.vmdata.program, self.dsp_i);
             let res =
                 vm::Machine::get_as_array::<f64>(self.vmdata.vm.get_top_n(self.dsp_ochannels));
-            // let phase = ((self.count as f64) *440f64 / 44100f64) % 1.0;
-            // let res = (phase* std::f64::consts::PI *2.0).sin();
             self.count
                 .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
             match (h_ochannels, self.dsp_ochannels) {

--- a/mimium-audiodriver/tests/getnow.rs
+++ b/mimium-audiodriver/tests/getnow.rs
@@ -1,8 +1,9 @@
 use mimium_audiodriver::{backends::mock::MockDriver, driver::SampleRate};
 use mimium_lang::{
+    function,
     interner::ToSymbol as _,
     numeric,
-    runtime::vm::{FuncProto, Instruction, Machine, Program},
+    runtime::vm::{FuncProto, Instruction, Program},
     types::{PType, Type},
 };
 
@@ -22,15 +23,16 @@ fn getnow_test() {
         state_size: 0,
     };
     let inner_insts = vec![
-        Instruction::CallExtCls(0, 0, 1), //call getnow, 7 should be set at reg 0
-        Instruction::Return(0, 1),        // return single value at 1
+        Instruction::MoveConst(0, 0),     //load constant 0 for closure index
+        Instruction::CallExtCls(0, 0, 1), //call getnow
+        Instruction::Return(0, 1),        // return single value at 0
     ];
     let dsp_f = FuncProto {
         nparam: 0,
         nret: 1,
         upindexes: vec![],
         bytecodes: inner_insts,
-        constants: vec![], //cls, int 4
+        constants: vec![0], //cls,
         delay_sizes: vec![],
         state_size: 0,
     };
@@ -39,7 +41,7 @@ fn getnow_test() {
     let prog = Program {
         global_fn_table: fns,
         ext_fun_table: vec![],
-        ext_cls_table: vec![("_mimium_getnow".to_symbol(), numeric!())],
+        ext_cls_table: vec![("_mimium_getnow".to_symbol(), function!(vec![], numeric!()))],
         global_vals: vec![],
     };
 

--- a/mimium-cli/examples/getnow.mmm
+++ b/mimium-cli/examples/getnow.mmm
@@ -1,0 +1,5 @@
+fn dsp(){
+    let time = now * 440.0 / 48000.0
+    let nphase = time % 1.0 
+    sin(nphase*6.2831853)
+}

--- a/mimium-lang/src/compiler/bytecodegen.rs
+++ b/mimium-lang/src/compiler/bytecodegen.rs
@@ -467,7 +467,7 @@ impl ByteCodeGenerator {
                     }
                     mir::Value::ExtFunction(label, ty) => {
                         let (dst, argsize, nret) =
-                        self.prepare_extfun(funcproto, bytecodes_dst, dst, args, *label, *ty);
+                        self.prepare_extcls(funcproto, bytecodes_dst, dst, args, *label, *ty);
                     Some(VmInstruction::CallExtCls(dst, argsize, nret))
                     }
                     _ => unreachable!(),

--- a/mimium-lang/src/compiler/mirgen.rs
+++ b/mimium-lang/src/compiler/mirgen.rs
@@ -2,7 +2,7 @@ use super::intrinsics;
 use super::typing::{self, infer_root, InferContext};
 use crate::interner::{ExprNodeId, Symbol, ToSymbol, TypeNodeId};
 use crate::pattern::{Pattern, TypedId, TypedPattern};
-use crate::{numeric, unit};
+use crate::{function, numeric, unit};
 pub(crate) mod recursecheck;
 pub mod selfconvert;
 use crate::mir::{self, Argument, Instruction, Mir, StateSize, VPtr, VReg, Value};
@@ -299,7 +299,12 @@ impl Context {
                 f.parse::<f64>().expect("illegal float format"),
             )),
             Literal::SelfLit => unreachable!(),
-            Literal::Now => todo!(),
+            Literal::Now => {
+                let ftype = numeric!();
+                let fntype = function!(vec![], ftype);
+                let getnow = Arc::new(Value::ExtFunction("_mimium_getnow".to_symbol(), fntype));
+                self.push_inst(Instruction::CallCls(getnow, vec![], ftype))
+            }
         };
         Ok(v)
     }

--- a/mimium-lang/src/compiler/parser.rs
+++ b/mimium-lang/src/compiler/parser.rs
@@ -127,9 +127,9 @@ where
 
 type ExprParser<'a> = Recursive<'a, Token, ExprNodeId, Simple<Token>>;
 
-fn items_parser<'a>(
-    expr: ExprParser<'a>,
-) -> impl Parser<Token, Vec<ExprNodeId>, Error = Simple<Token>> + Clone + 'a {
+fn items_parser(
+    expr: ExprParser<'_>,
+) -> impl Parser<Token, Vec<ExprNodeId>, Error = Simple<Token>> + Clone + '_ {
     expr.separated_by(just(Token::Comma))
         .allow_trailing()
         .collect::<Vec<_>>()

--- a/mimium-lang/src/mir.rs
+++ b/mimium-lang/src/mir.rs
@@ -51,7 +51,7 @@ pub enum Instruction {
         array_idx: u64,
         tuple_offset: u64,
     },
-    // call function, arguments
+    // call function, arguments, type of return value
     Call(VPtr, Vec<(VPtr, TypeNodeId)>, TypeNodeId),
     CallCls(VPtr, Vec<(VPtr, TypeNodeId)>, TypeNodeId),
     GetGlobal(VPtr, TypeNodeId),

--- a/mimium-lang/src/runtime/vm.rs
+++ b/mimium-lang/src/runtime/vm.rs
@@ -526,12 +526,11 @@ impl Machine {
                     self.stack.truncate(base + func as usize + nret as usize);
                 }
                 Instruction::CallExtCls(func, nargs, nret_req) => {
-                    // todo: load closure index via constant for the case of more than 255 closures in program
-                    // let cls_idx = self
-                    //     .cls_map
-                    //     .get(&(self.get_stack(func as i64) as usize))
-                    //     .expect("closure map not resolved.");
-                    let (_name, cls) = self.ext_cls_table[func as usize].clone();
+                    let cls_idx = self
+                        .cls_map
+                        .get(&(self.get_stack(func as i64) as usize))
+                        .expect("closure map not resolved.");
+                    let (_name, cls) = &self.ext_cls_table[*cls_idx];
                     let cls = cls.clone();
                     self.call_function(func, nargs, nret_req, move |machine| cls(machine));
                 }

--- a/mimium-lang/src/runtime/vm.rs
+++ b/mimium-lang/src/runtime/vm.rs
@@ -300,12 +300,12 @@ impl Machine {
     }
 
     pub fn set_stack(&mut self, offset: i64, v: RawVal) {
-        self.set_stack_range(offset, &v as *const RawVal, 1)
+        self.set_stack_range(offset, &[v])
     }
-    pub fn set_stack_range(&mut self, offset: i64, v: *const RawVal, size: usize) {
-        debug_assert!(!v.is_null());
+    pub fn set_stack_range(&mut self, offset: i64, vs: &[RawVal]) {
+        // debug_assert!(!v.is_null());
         // debug_assert!(v.is_aligned());
-        let vs = unsafe { slice::from_raw_parts(v, size) };
+        // let vs = unsafe { slice::from_raw_parts(v, size) };
         set_vec_range(
             &mut self.stack,
             (self.base_pointer as i64 + offset) as usize,
@@ -568,7 +568,7 @@ impl Machine {
                         match rv {
                             UpValue::Open(i) => {
                                 let upper_base = cls.base_ptr as usize;
-                                let (range, rawv) = self.get_open_upvalue(upper_base, *i);
+                                let (range, _rawv) = self.get_open_upvalue(upper_base, *i);
                                 // log::trace!("open {}", unsafe {
                                 //     std::mem::transmute::<u64, f64>(rawv[0])
                                 // });
@@ -576,17 +576,10 @@ impl Machine {
                                 self.move_stack_range(dst as _, range);
                             }
                             UpValue::Closed(rawval) => {
-                                let (ptr, len) = {
-                                    let rawv = rawval.borrow();
-                                    // log::trace!("close{:?}", unsafe {
-                                    //     std::mem::transmute::<u64, f64>(rawv[0])
-                                    // });
-                                    let ptr = rawv.as_ptr();
-                                    let len = rawv.len();
-                                    assert_eq!(rawv.len(), size as usize);
-                                    (ptr, len)
-                                };
-                                self.set_stack_range(dst as i64, ptr, len);
+                                //force borrow because closure cell and stack never collisions
+                                let rawv: &[RawVal] =
+                                    unsafe { std::mem::transmute(rawval.borrow().as_slice()) };
+                                self.set_stack_range(dst as i64, rawv);
                             }
                         };
                     };
@@ -617,7 +610,7 @@ impl Machine {
                         // debug_assert!(vstart.is_aligned());
                         slice::from_raw_parts(vstart, size as _)
                     };
-                    self.set_stack_range(dst as i64, gvs.as_ptr(), gvs.len())
+                    self.set_stack_range(dst as i64, gvs)
                 }
                 Instruction::SetGlobal(gid, src, size) => {
                     let gvs = unsafe {
@@ -686,10 +679,11 @@ impl Machine {
                     Self::to_value::<bool>(Self::get_as::<i64>(self.get_stack(src as i64)) != 0),
                 ),
                 Instruction::GetState(dst, size) => {
-                    let v = self.get_current_state().get_state(size as _);
-                    let ptr = v.as_ptr();
-                    let size = v.len();
-                    self.set_stack_range(dst as i64, ptr, size);
+                    //force borrow because state storage and stack never collisions
+                    let v: &[RawVal] = unsafe {
+                        std::mem::transmute(self.get_current_state().get_state(size as _))
+                    };
+                    self.set_stack_range(dst as i64, v);
                 }
                 Instruction::SetState(src, size) => {
                     let vs = {

--- a/mimium-lang/src/runtime/vm/test.rs
+++ b/mimium-lang/src/runtime/vm/test.rs
@@ -184,7 +184,7 @@ fn rust_closure_test() {
     };
     let fns = vec![main_f];
     let fnames = vec!["main".to_symbol()];
-    let global_fn_table = fnames.into_iter().zip(fns.into_iter()).collect::<Vec<_>>();
+    let global_fn_table = fnames.into_iter().zip(fns).collect::<Vec<_>>();
     // let mut count = 0;
     let cls = Arc::new(|m: &mut Machine| {
         let v = m.get_top_n(1)[0];
@@ -192,7 +192,7 @@ fn rust_closure_test() {
         println!("Call from closure: {}", i);
         //?????
         m.set_stack(-1, Machine::to_value(i));
-        return 1;
+        1
     });
     let mut machine = Machine::new();
     machine.install_extern_fn("lib_printi".to_symbol(), lib_printi);
@@ -203,6 +203,7 @@ fn rust_closure_test() {
         ext_cls_table: vec![("rustclosure".to_symbol(), Type::Unknown.into_id())],
         global_vals: vec![],
     };
+    machine.link_functions(&prog);
     // let mut feedstate = FeedState::default();
     let res = machine.execute_main(&prog);
     assert_eq!(res, 0);


### PR DESCRIPTION
Continued from #39 .

This PR adds syntactic sugar from a reserved word `now` to the built-in closure call `_mimium_getnow()`.

This includes a small refactoring in code generator.
With this PR, the first argument for `CallExtCls` instruction is no longer an absolute index of closures in the program but a register position to indicate the closure index, as `CallExtFun` does it.