### PR TITLE
Reserve index for dsp

### DIFF
--- a/mimium-audiodriver/src/backends/cpal.rs
+++ b/mimium-audiodriver/src/backends/cpal.rs
@@ -5,6 +5,7 @@ use crate::driver::{Driver, RuntimeData, SampleRate, Time};
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 use cpal::{self, BufferSize, StreamConfig};
 use mimium_lang::interner::{Symbol, ToSymbol};
+use mimium_lang::mir::FN_INDEX_DSP;
 use mimium_lang::runtime::vm::{self, ExtClsType, Machine, ReturnCode};
 use ringbuf::traits::{Consumer, Producer, Split};
 use ringbuf::{HeapCons, HeapProd, HeapRb};
@@ -35,7 +36,6 @@ impl Default for NativeDriver {
 //Runtime data, which will be created and immidiately send to audio thread.
 struct NativeAudioData {
     pub vmdata: RuntimeData,
-    dsp_i: usize,
     dsp_ochannels: usize,
     buffer: HeapCons<f64>,
     localbuffer: Vec<f64>,
@@ -45,10 +45,9 @@ unsafe impl Send for NativeAudioData {}
 
 impl NativeAudioData {
     pub fn new(program: vm::Program, buffer: HeapCons<f64>, count: Arc<AtomicU64>) -> Self {
-        let dsp_i = program
-            .get_fun_index(&"dsp".to_symbol())
-            .expect("no dsp function found");
-        let (_, dsp_func) = &program.global_fn_table[dsp_i];
+        let dsp_func = program
+            .get_dsp_fn()
+            .expect("Program should have dsp function");
         let dsp_ochannels = dsp_func.nret;
         //todo: split as trait interface method
         let getnow_fn: (Symbol, ExtClsType) = (
@@ -59,7 +58,6 @@ impl NativeAudioData {
         let localbuffer: Vec<f64> = vec![0.0f64; 4096];
         Self {
             vmdata,
-            dsp_i,
             dsp_ochannels,
             buffer,
             localbuffer,
@@ -74,7 +72,10 @@ impl NativeAudioData {
             .chunks_mut(h_ochannels)
             .zip(local.chunks(self.dsp_ochannels))
         {
-            let _rc = self.vmdata.vm.execute_idx(&self.vmdata.program, self.dsp_i);
+            let _rc = self
+                .vmdata
+                .vm
+                .execute_idx(&self.vmdata.program, FN_INDEX_DSP);
             let res =
                 vm::Machine::get_as_array::<f64>(self.vmdata.vm.get_top_n(self.dsp_ochannels));
             self.count

--- a/mimium-audiodriver/src/backends/mock.rs
+++ b/mimium-audiodriver/src/backends/mock.rs
@@ -23,10 +23,9 @@ impl MockDriver {
         program: mimium_lang::runtime::vm::Program,
         sample_rate: Option<SampleRate>,
     ) -> Self {
-        let dsp_i = program
-            .get_fun_index(&"dsp".to_symbol())
-            .expect("no dsp function found");
-        let (_, dsp_func) = &program.global_fn_table[dsp_i];
+        let dsp_func = program
+            .get_dsp_fn()
+            .expect("Program should have dsp function");
         let ochannels = dsp_func.nret as u64;
         let count = Arc::new(AtomicU64::new(0));
         //todo: split as trait interface method

--- a/mimium-audiodriver/src/driver.rs
+++ b/mimium-audiodriver/src/driver.rs
@@ -1,5 +1,6 @@
 use mimium_lang::{
     interner::{Symbol, ToSymbol},
+    mir::FN_INDEX_DSP,
     runtime::vm::{self, ExtClsType, ExtFunType, Machine, ReturnCode},
     utils::error::ReportableError,
 };
@@ -72,7 +73,6 @@ pub trait Driver {
 pub struct RuntimeData {
     pub program: vm::Program,
     pub vm: vm::Machine,
-    dsp_i: usize,
 }
 impl RuntimeData {
     pub fn new(
@@ -89,14 +89,16 @@ impl RuntimeData {
         });
         vm.link_functions(&program);
         //todo:error handling
-        let dsp_i = program.get_fun_index(&"dsp".to_symbol()).unwrap_or(0);
-        Self { program, vm, dsp_i }
+        if program.get_dsp_fn().is_none() {
+            panic!("Program doesn't have `dsp` function")
+        }
+        Self { program, vm }
     }
     pub fn run_main(&mut self) -> ReturnCode {
         self.vm.execute_main(&self.program)
     }
     pub fn run_dsp(&mut self) -> ReturnCode {
-        self.vm.execute_idx(&self.program, self.dsp_i)
+        self.vm.execute_idx(&self.program, FN_INDEX_DSP)
     }
 }
 

--- a/mimium-lang/benches/bench.rs
+++ b/mimium-lang/benches/bench.rs
@@ -11,6 +11,7 @@ mod tests {
     mod runtime {
         use mimium_lang::compiler::emit_bytecode;
         use mimium_lang::interner::ToSymbol;
+        use mimium_lang::mir::FN_INDEX_DSP;
         use mimium_lang::runtime::vm::Machine;
         use test::Bencher;
 
@@ -50,8 +51,7 @@ fn dsp(){{
             let mut machine = Machine::new();
             machine.link_functions(&program);
             machine.execute_main(&program);
-            let idx = program.get_fun_index(&"dsp".to_symbol()).expect("ok");
-            b.iter(move || machine.execute_idx(&program, idx));
+            b.iter(move || machine.execute_idx(&program, FN_INDEX_DSP));
         }
         #[bench]
         fn bench_multiosc5(b: &mut Bencher) {

--- a/mimium-lang/benches/bench.rs
+++ b/mimium-lang/benches/bench.rs
@@ -10,7 +10,6 @@ mod tests {
 
     mod runtime {
         use mimium_lang::compiler::emit_bytecode;
-        use mimium_lang::interner::ToSymbol;
         use mimium_lang::mir::FN_INDEX_DSP;
         use mimium_lang::runtime::vm::Machine;
         use test::Bencher;

--- a/mimium-lang/src/compiler.rs
+++ b/mimium-lang/src/compiler.rs
@@ -14,7 +14,7 @@ pub enum ErrorKind {
     VariableNotFound(String),
     NonPrimitiveInFeed,
     NotApplicable, //need?
-    NoMainFunction,
+    NoDspFunction,
     Unknown,
 }
 #[derive(Debug, Clone)]
@@ -49,7 +49,7 @@ impl std::fmt::Display for ErrorKind {
             }
             ErrorKind::CircularType => write!(f, "Circular loop of type definition"),
             ErrorKind::NonPrimitiveInFeed => write!(f, "Feed can take only non-funtion type."),
-            ErrorKind::NoMainFunction => write!(f, "`dsp` function is not defined."),
+            ErrorKind::NoDspFunction => write!(f, "`dsp` function is not defined."),
             ErrorKind::Unknown => write!(f, "unknwon error."),
         }
     }

--- a/mimium-lang/src/compiler.rs
+++ b/mimium-lang/src/compiler.rs
@@ -14,6 +14,7 @@ pub enum ErrorKind {
     VariableNotFound(String),
     NonPrimitiveInFeed,
     NotApplicable, //need?
+    NoMainFunction,
     Unknown,
 }
 #[derive(Debug, Clone)]
@@ -48,6 +49,7 @@ impl std::fmt::Display for ErrorKind {
             }
             ErrorKind::CircularType => write!(f, "Circular loop of type definition"),
             ErrorKind::NonPrimitiveInFeed => write!(f, "Feed can take only non-funtion type."),
+            ErrorKind::NoMainFunction => write!(f, "`dsp` function is not defined."),
             ErrorKind::Unknown => write!(f, "unknwon error."),
         }
     }
@@ -90,7 +92,7 @@ pub fn emit_mir(src: &str) -> Result<Mir, Vec<Box<dyn ReportableError>>> {
 }
 pub fn emit_bytecode(src: &str) -> Result<vm::Program, Vec<Box<dyn ReportableError>>> {
     let mir = emit_mir(src)?;
-    bytecodegen::gen_bytecode(mir)
+    bytecodegen::gen_bytecode(mir, true)
 }
 
 pub fn interpret_top(

--- a/mimium-lang/src/compiler/bytecodegen.rs
+++ b/mimium-lang/src/compiler/bytecodegen.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 
 use crate::interner::{Symbol, TypeNodeId};
-use crate::mir::{self, Mir, StateSize, DSP_FN_INDEX, GLOBAL_FN_INDEX};
+use crate::mir::{self, Mir, StateSize, FN_INDEX_DSP, FN_INDEX_GLOBAL};
 use crate::runtime::vm::bytecode::{ConstPos, GlobalPos, Reg};
 use crate::runtime::vm::{self};
 use crate::types::{Type, TypeSize};
@@ -710,7 +710,7 @@ impl ByteCodeGenerator {
         let functions = if has_entry_point {
             // if the code has entry points, _mimium_global and dsp must be
             // defined at this point.
-            for i in [GLOBAL_FN_INDEX, DSP_FN_INDEX] {
+            for i in [FN_INDEX_GLOBAL, FN_INDEX_DSP] {
                 if !mir.functions[i].is_defined {
                     let e = Box::new(Error(ErrorKind::NoMainFunction, 0..0));
                     return Err(vec![e]);
@@ -718,7 +718,7 @@ impl ByteCodeGenerator {
             }
             &mut mir.functions
         } else {
-            &mut mir.functions[(DSP_FN_INDEX + 1)..]
+            &mut mir.functions[(FN_INDEX_DSP + 1)..]
         };
 
         self.program.global_fn_table = functions

--- a/mimium-lang/src/compiler/bytecodegen.rs
+++ b/mimium-lang/src/compiler/bytecodegen.rs
@@ -828,7 +828,7 @@ mod test {
             mir::Instruction::Return(res.clone(), numeric!()),
         ));
         func.body = vec![block];
-        src.add_function(func);
+        src.add_function(func).unwrap();
         let mut generator = ByteCodeGenerator::default();
         let res = generator.generate(src);
 

--- a/mimium-lang/src/compiler/bytecodegen.rs
+++ b/mimium-lang/src/compiler/bytecodegen.rs
@@ -712,7 +712,7 @@ impl ByteCodeGenerator {
             // defined at this point.
             for i in [FN_INDEX_GLOBAL, FN_INDEX_DSP] {
                 if !mir.functions[i].is_defined {
-                    let e = Box::new(Error(ErrorKind::NoMainFunction, 0..0));
+                    let e = Box::new(Error(ErrorKind::NoDspFunction, 0..0));
                     return Err(vec![e]);
                 }
             }

--- a/mimium-lang/src/compiler/mirgen.rs
+++ b/mimium-lang/src/compiler/mirgen.rs
@@ -5,14 +5,16 @@ use crate::pattern::{Pattern, TypedId, TypedPattern};
 use crate::{function, numeric, unit};
 pub(crate) mod recursecheck;
 pub mod selfconvert;
-use crate::mir::{self, Argument, Instruction, Mir, StateSize, VPtr, VReg, Value};
+use crate::mir::{
+    self, Argument, Instruction, Mir, StateSize, VPtr, VReg, Value, FN_INDEX_DSP, FN_INDEX_GLOBAL,
+};
 
 use std::sync::Arc;
 
 use crate::types::{PType, Type};
 use crate::utils::environment::{Environment, LookupRes};
 use crate::utils::error::ReportableError;
-use crate::utils::metadata::{Span, GLOBAL_LABEL};
+use crate::utils::metadata::{Span, DSP_LABEL, GLOBAL_LABEL};
 
 use crate::ast::{Expr, Literal};
 // pub mod closure_convert;
@@ -247,12 +249,12 @@ impl Context {
         let newf = mir::Function::new(name, args, argtypes, parent_i);
         match name.as_str() {
             GLOBAL_LABEL => {
-                self.program.functions[0] = newf;
-                0
+                self.program.functions[FN_INDEX_GLOBAL] = newf;
+                FN_INDEX_GLOBAL
             }
-            "dsp" => {
-                self.program.functions[1] = newf;
-                1
+            DSP_LABEL => {
+                self.program.functions[FN_INDEX_DSP] = newf;
+                FN_INDEX_DSP
             }
             _ => {
                 self.program.functions.push(newf);

--- a/mimium-lang/src/compiler/mirgen.rs
+++ b/mimium-lang/src/compiler/mirgen.rs
@@ -73,7 +73,7 @@ impl Context {
 
     fn get_current_fn(&mut self) -> &mut mir::Function {
         let i = self.get_ctxdata().func_i;
-        self.program.get_function_ref_mut(i)
+        self.program.get_function_ref_mut(i).unwrap()
     }
     fn make_delay(&mut self, f: &VPtr, args: &[ExprNodeId]) -> Result<Option<VPtr>, CompileError> {
         let rt = match f.as_ref() {
@@ -274,7 +274,7 @@ impl Context {
         let (fptr, ty) = action(self, c_idx)?;
 
         // TODO: ideally, type should be infered before the actual action
-        let f = self.program.get_function_ref_mut(c_idx);
+        let f = self.program.get_function_ref_mut(c_idx).unwrap();
         f.return_type.get_or_init(|| ty);
 
         //post action
@@ -326,7 +326,7 @@ impl Context {
             LookupRes::UpValue(level, v) => (0..level).rev().fold(v, |upv, i| {
                 let res = self.gen_new_register();
                 let current = self.data.get_mut(self.data_i - i).unwrap();
-                let currentf = self.program.get_function_ref_mut(current.func_i);
+                let currentf = self.program.get_function_ref_mut(current.func_i).unwrap();
                 let upi = currentf.get_or_insert_upvalue(&upv) as _;
                 let currentbb = currentf.body.get_mut(current.current_bb).unwrap();
 
@@ -392,6 +392,7 @@ impl Context {
         let state_sizes = self
             .program
             .get_function_ref(idx as usize)
+            .unwrap()
             .state_sizes
             .clone();
 
@@ -620,7 +621,7 @@ impl Context {
                     let f = Arc::new(Value::Function(c_idx));
                     Ok((f, rt))
                 })?;
-                let child = self.program.get_function_ref_mut(c_idx);
+                let child = self.program.get_function_ref_mut(c_idx).unwrap();
                 let res = if child.upindexes.is_empty() {
                     //todo:make Closure
                     f
@@ -811,5 +812,5 @@ pub fn compile(root_expr_id: ExprNodeId) -> Result<Mir, Box<dyn ReportableError>
         let eb: Box<dyn ReportableError> = Box::new(e);
         eb
     })?;
-    Ok(ctx.program.clone())
+    Ok(ctx.program)
 }

--- a/mimium-lang/src/mir.rs
+++ b/mimium-lang/src/mir.rs
@@ -205,7 +205,7 @@ impl Function {
 
 #[derive(Debug, Clone)]
 pub struct Mir {
-    pub functions: Vec<Function>,
+    functions: Vec<Function>,
 }
 
 pub const FN_INDEX_GLOBAL: usize = 0;
@@ -220,5 +220,48 @@ impl Default for Mir {
                 Function::new_stub(DSP_LABEL.to_symbol()),
             ],
         }
+    }
+}
+
+impl Mir {
+    pub fn add_function(&mut self, func: Function) -> usize {
+        match func.label.as_str() {
+            GLOBAL_LABEL => {
+                self.functions[FN_INDEX_GLOBAL] = func;
+                FN_INDEX_GLOBAL
+            }
+            DSP_LABEL => {
+                self.functions[FN_INDEX_DSP] = func;
+                FN_INDEX_DSP
+            }
+            _ => {
+                self.functions.push(func);
+                self.functions.len() - 1
+            }
+        }
+    }
+
+    pub fn into_functions(self) -> Vec<Function> {
+        self.functions
+    }
+
+    pub fn get_function_ref(&self, idx: usize) -> &Function {
+        self.functions.get(idx).unwrap()
+    }
+
+    pub fn get_function_ref_mut(&mut self, idx: usize) -> &mut Function {
+        self.functions.get_mut(idx).unwrap()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        !self.functions.iter().any(|f| f.is_defined)
+    }
+
+    pub fn cur_idx(&self) -> usize {
+        self.functions.len() - 1
+    }
+
+    pub fn next_idx(&self) -> usize {
+        self.functions.len()
     }
 }

--- a/mimium-lang/src/mir.rs
+++ b/mimium-lang/src/mir.rs
@@ -241,7 +241,11 @@ impl Mir {
         }
     }
 
-    pub fn into_functions(self) -> Vec<Function> {
+    pub fn into_functions(mut self, with_entry_point: bool) -> Vec<Function> {
+        if !with_entry_point {
+            self.functions.drain(0..=FN_INDEX_DSP);
+        }
+
         self.functions
     }
 

--- a/mimium-lang/src/mir.rs
+++ b/mimium-lang/src/mir.rs
@@ -208,8 +208,8 @@ pub struct Mir {
     pub functions: Vec<Function>,
 }
 
-pub(crate) const GLOBAL_FN_INDEX: usize = 0;
-pub(crate) const DSP_FN_INDEX: usize = 1;
+pub const FN_INDEX_GLOBAL: usize = 0;
+pub const FN_INDEX_DSP: usize = 1;
 
 impl Default for Mir {
     fn default() -> Self {

--- a/mimium-lang/src/mir.rs
+++ b/mimium-lang/src/mir.rs
@@ -241,22 +241,6 @@ impl Mir {
         }
     }
 
-    pub fn into_functions(mut self, with_entry_point: bool) -> Vec<Function> {
-        if !with_entry_point {
-            self.functions.drain(0..=FN_INDEX_DSP);
-        }
-
-        self.functions
-    }
-
-    pub fn get_function_ref(&self, idx: usize) -> &Function {
-        self.functions.get(idx).unwrap()
-    }
-
-    pub fn get_function_ref_mut(&mut self, idx: usize) -> &mut Function {
-        self.functions.get_mut(idx).unwrap()
-    }
-
     pub fn is_empty(&self) -> bool {
         !self.functions.iter().any(|f| f.is_defined)
     }
@@ -267,5 +251,25 @@ impl Mir {
 
     pub fn next_idx(&self) -> usize {
         self.functions.len()
+    }
+
+    // outputs contain functions that are actually defined
+
+    pub fn iter(&self) -> impl Iterator<Item = &Function> {
+        self.functions.iter().filter(|f| f.is_defined)
+    }
+
+    pub fn get_function_ref(&self, idx: usize) -> Option<&Function> {
+        match self.functions.get(idx) {
+            Some(func) if func.is_defined => Some(func),
+            _ => None,
+        }
+    }
+
+    pub fn get_function_ref_mut(&mut self, idx: usize) -> Option<&mut Function> {
+        match self.functions.get_mut(idx) {
+            Some(func) if func.is_defined => Some(func),
+            _ => None,
+        }
     }
 }

--- a/mimium-lang/src/mir/print.rs
+++ b/mimium-lang/src/mir/print.rs
@@ -25,7 +25,7 @@ fn display_state_sizes<T: AsRef<[StateSize]>>(x: T) -> String {
 
 impl std::fmt::Display for Mir {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        for fun in self.functions.iter() {
+        for fun in self.iter() {
             let af = fun
                 .args
                 .iter()

--- a/mimium-lang/src/runtime.rs
+++ b/mimium-lang/src/runtime.rs
@@ -1,5 +1,6 @@
 use crate::compiler;
 use crate::interner::ToSymbol;
+use crate::mir::{FN_INDEX_DSP, FN_INDEX_GLOBAL};
 use crate::utils::{error::ReportableError, metadata::Span};
 
 pub mod scheduler;
@@ -42,7 +43,7 @@ pub fn run_bytecode_test<'a>(
     bytecodes: &'a vm::Program,
     n: usize,
 ) -> Result<&'a [f64], Vec<Box<dyn ReportableError>>> {
-    let retcode = machine.execute_entry(bytecodes, &"dsp".to_symbol());
+    let retcode = machine.execute_idx(bytecodes, FN_INDEX_DSP);
     if retcode >= 0 {
         Ok(vm::Machine::get_as_array::<f64>(machine.get_top_n(n)))
     } else {
@@ -57,7 +58,7 @@ pub fn run_bytecode_test_multiple(
 ) -> Result<Vec<f64>, Vec<Box<dyn ReportableError>>> {
     let mut machine = vm::Machine::new();
     machine.link_functions(bytecodes);
-    let _retcode = machine.execute_entry(bytecodes, &"_mimium_global".to_symbol());
+    let _retcode = machine.execute_idx(bytecodes, FN_INDEX_GLOBAL);
     let n = if stereo { 2 } else { 1 };
     let mut ret = Vec::with_capacity(times as usize * n);
     for i in 0..times {

--- a/mimium-lang/src/runtime.rs
+++ b/mimium-lang/src/runtime.rs
@@ -1,5 +1,4 @@
 use crate::compiler;
-use crate::interner::ToSymbol;
 use crate::mir::{FN_INDEX_DSP, FN_INDEX_GLOBAL};
 use crate::utils::{error::ReportableError, metadata::Span};
 

--- a/mimium-lang/src/runtime/vm/program.rs
+++ b/mimium-lang/src/runtime/vm/program.rs
@@ -1,5 +1,5 @@
 use super::{Instruction, RawVal};
-use crate::interner::{Symbol, ToSymbol, TypeNodeId};
+use crate::interner::{Symbol, TypeNodeId};
 use crate::mir::{self, FN_INDEX_DSP};
 pub use mir::OpenUpValue;
 

--- a/mimium-lang/src/runtime/vm/program.rs
+++ b/mimium-lang/src/runtime/vm/program.rs
@@ -1,6 +1,6 @@
 use super::{Instruction, RawVal};
 use crate::interner::{Symbol, ToSymbol, TypeNodeId};
-use crate::mir;
+use crate::mir::{self, FN_INDEX_DSP};
 pub use mir::OpenUpValue;
 
 #[derive(Debug, Default, Clone, PartialEq)]
@@ -48,8 +48,9 @@ impl Program {
             .position(|(label, _f)| label == name)
     }
     pub fn get_dsp_fn(&self) -> Option<&FuncProto> {
-        self.get_fun_index(&"dsp".to_symbol())
-            .and_then(|idx| self.global_fn_table.get(idx).map(|(_, f)| f))
+        self.global_fn_table
+            .get(FN_INDEX_DSP)
+            .map(|(_, func_proto)| func_proto)
     }
 }
 

--- a/mimium-lang/src/utils/metadata.rs
+++ b/mimium-lang/src/utils/metadata.rs
@@ -1,21 +1,4 @@
 pub type Span = std::ops::Range<usize>;
 
-// #[derive(Clone, Debug, PartialEq)]
-// pub struct WithMeta<T>{
-//     pub location: Span,
-//     pub value : T
-// }
 pub(crate) const GLOBAL_LABEL: &'static str = "_mimium_global";
-
-// #[derive(Clone, Debug, PartialEq)]
-// pub struct WithMeta<T: Clone + PartialEq>(pub T, pub Span);
-
-// impl<T: Clone + PartialEq> WithMeta<T> {
-//     fn map<F, O>(self, f: F) -> WithMeta<O>
-//     where
-//         F: FnOnce(T) -> O,
-//         O: Clone + PartialEq,
-//     {
-//         WithMeta(f(self.0), self.1)
-//     }
-// }
+pub(crate) const DSP_LABEL: &'static str = "dsp";


### PR DESCRIPTION
The original motivation of this pull request was to add a validation to ensure the program has `dsp` function. After some experiment, I think the index of the `dsp` function can be predetermined just like `_mimium_global`. By fixing the index, the runtime doesn't need to track `dsp_i`.

I come up with the following two options, and I chose option 1 because this seemed relatively simple.

1. Add a flag to `Function` to indicate if the function is defined
2. Add a dedicated field (e.g. `dsp_function: Option<Function>`) to `Mir`

But, this makes the implementation slightly complex. `mirgen` needs to care a bit more about the status of the function. Does this look good to you?

Remaining questions:

* Is this implementation also sound with the cases of compiling libraries?
* Are there any case that a source code has multiple `dsp` functions?