### PR TITLE
Validate schedule before setting

### DIFF
--- a/mimium-cli/tests/mmm/scheduler_invalid.mmm
+++ b/mimium-cli/tests/mmm/scheduler_invalid.mmm
@@ -1,0 +1,10 @@
+let x = 0.0
+
+fn updater(){
+    x = x + 1.0
+    _mimium_schedule_at(now,updater)
+}
+let _ = _mimium_schedule_at(1.0,updater)
+fn dsp(){
+    x
+}

--- a/mimium-cli/tests/scheduler_test.rs
+++ b/mimium-cli/tests/scheduler_test.rs
@@ -8,6 +8,13 @@ fn scheduler_global_recursion() {
     assert_eq!(res, ans);
 }
 
+#[test]
+#[should_panic]
+fn scheduler_invalid() {
+    // recursion with @now would cause infinite recursion, so this should be errored.
+    let _ = run_file_with_scheduler("scheduler_invalid.mmm", 10);
+}
+
 // #[test]
 // fn scheduler_counter() {
 //     let res = run_file_with_scheduler("scheduler_counter.mmm", 10).unwrap();

--- a/mimium-lang/src/runtime/vm.rs
+++ b/mimium-lang/src/runtime/vm.rs
@@ -836,6 +836,8 @@ impl Machine {
         self.execute(0, prog, None)
     }
     pub fn execute_task(&mut self, now: Time, prog: &Program) {
+        self.scheduler.set_cur_time(now);
+
         if let Some(task_cls) = self.scheduler.pop_task(now, prog) {
             log::debug!("task id {:?}", task_cls);
             let closure = self.get_closure(task_cls);


### PR DESCRIPTION
This pull request is a naive implementation of the validation suggested in https://github.com/tomoyanonymous/mimium-rs/pull/41#issuecomment-2332095814. The expressions like following ones will fail.

```
// past
fn updater(){
    x = x + 1.0
    _mimium_schedule_at(now-1.0,updater)
}
```

```
// now, which means infinite recursion in theory
fn updater(){
    x = x + 1.0
    _mimium_schedule_at(now,updater)
}
```