### PR TITLE
Fix the scheduler to process multiple tasks at a same time period.

### DIFF
--- a/mimium-cli/tests/mmm/scheduler_invalid.mmm
+++ b/mimium-cli/tests/mmm/scheduler_invalid.mmm
@@ -1,3 +1,4 @@
+// this code falls into an infinite task execution loop.
 let x = 0.0
 
 fn updater(){

--- a/mimium-cli/tests/mmm/scheduler_multiple_at_sametime.mmm
+++ b/mimium-cli/tests/mmm/scheduler_multiple_at_sametime.mmm
@@ -1,0 +1,13 @@
+// this code execute updater twice at a time, from time 1.0
+// answer should be 0.0, 2.0, 4.0
+let x = 0.0
+
+fn updater(){
+    x = x + 1.0
+    updater@(now+1.0)
+}
+updater@1.0
+updater@1.0
+fn dsp(){
+    x
+}

--- a/mimium-cli/tests/scheduler_test.rs
+++ b/mimium-cli/tests/scheduler_test.rs
@@ -9,6 +9,13 @@ fn scheduler_global_recursion() {
 }
 
 #[test]
+fn scheduler_multiple_at_sametime() {
+    let res = run_file_with_scheduler("scheduler_multiple_at_sametime.mmm", 5).unwrap();
+    let ans = vec![0.0, 2.0, 4.0, 6.0, 8.0];
+    assert_eq!(res, ans);
+}
+
+#[test]
 #[should_panic]
 fn scheduler_invalid() {
     // recursion with @now would cause infinite recursion, so this should be errored.

--- a/mimium-lang/src/runtime/scheduler.rs
+++ b/mimium-lang/src/runtime/scheduler.rs
@@ -59,7 +59,7 @@ impl Scheduler for SyncScheduler {
         match self.tasks.peek() {
             Some(Reverse(Task { when, cls })) if *when <= now => {
                 let res = Some(*cls);
-                self.tasks.pop();
+                let _ = self.tasks.pop();
                 res
             }
             _ => None,

--- a/mimium-lang/src/runtime/vm.rs
+++ b/mimium-lang/src/runtime/vm.rs
@@ -838,7 +838,7 @@ impl Machine {
     pub fn execute_task(&mut self, now: Time, prog: &Program) {
         self.scheduler.set_cur_time(now);
 
-        if let Some(task_cls) = self.scheduler.pop_task(now, prog) {
+        while let Some(task_cls) = self.scheduler.pop_task(now, prog) {
             log::debug!("task id {:?}", task_cls);
             let closure = self.get_closure(task_cls);
             self.execute(closure.fn_proto_pos, prog, Some(task_cls));


### PR DESCRIPTION
This PR fixes that the current scheduler processes only 1 tasks at most, even if the multiple tasks are registered.
The essential fix is just replacing `if` to `while` in the `vm.rs`.

Now the code like below works.

```rust
let x = 0.0

fn updater(){
    x = x + 1.0
    updater@(now+1.0)
}
updater@1.0
updater@1.0
fn dsp(){
    x
}
```

