### PR TITLE
Add `letrec` syntax

### DIFF
--- a/mimium-cli/tests/intergration_test.rs
+++ b/mimium-cli/tests/intergration_test.rs
@@ -221,6 +221,12 @@ fn closure_counter2() {
     assert_eq!(res, ans);
 }
 #[test]
+fn closure_escape_3nested() {
+    let res = run_file_test_mono("closure_escape_3nested.mmm", 5).unwrap();
+    let ans = vec![1.0, 2.0, 3.0, 4.0, 5.0];
+    assert_eq!(res, ans);
+}
+#[test]
 fn closure_counter_tuple() {
     let res = run_file_test_stereo("closure_counter_tuple.mmm", 5).unwrap();
     #[rustfmt::skip]
@@ -233,6 +239,7 @@ fn closure_counter_tuple() {
     ];
     assert_eq!(res, ans);
 }
+
 #[test]
 fn hof_state() {
     let res = run_file_test_mono("hof_state.mmm", 10).unwrap();

--- a/mimium-cli/tests/mmm/closure_escape_3nested.mmm
+++ b/mimium-cli/tests/mmm/closure_escape_3nested.mmm
@@ -1,0 +1,16 @@
+// open closure "inner" should be closed and escaped at the end of 'outer' context.
+fn outer(){
+  let x = 0.0
+  let inner = | | { 
+    x = x+1.0
+    x
+  } 
+  let mid = | | {inner}
+  mid
+}
+let mid = outer();
+let inner = mid();
+fn dsp(){
+ let r = inner()
+ r
+}

--- a/mimium-cli/tests/mmm/scheduler_counter.mmm
+++ b/mimium-cli/tests/mmm/scheduler_counter.mmm
@@ -1,14 +1,13 @@
+//more abstract pattern of counter using scheduler.
+//this requires that compiler can define a recursive closure inside function using `letrec`.
 fn makecounter(){
     let x = 0.0
-    let updater = | |{
+    letrec gen = | |{
         x = x+1.0
+       gen@(now+1.0)
     }
-    let gen = | |{
-        let _ = _mimium_schedule_at(now+1.0, gen)
-        updater()
-    }
+    gen@1.0
     let getter = | | {x}
-    let _ = _mimium_schedule_at(1.0,gen)
     getter
 }
 let x_getter = makecounter();

--- a/mimium-cli/tests/mmm/scheduler_counter_indirect.mmm
+++ b/mimium-cli/tests/mmm/scheduler_counter_indirect.mmm
@@ -1,0 +1,16 @@
+//more abstract pattern of counter using scheduler.
+//this requires that compiler can define a recursive closure inside function using `letrec`.
+fn makecounter(){
+    let x = 0.0
+    letrec gen = | |{
+        x = x+1.0
+       | |{gen()}@(now+1.0)
+    }
+    | |{gen() }@1.0
+    let getter = | | {x}
+    getter
+}
+let x_getter = makecounter();
+fn dsp(){
+    x_getter()
+}

--- a/mimium-cli/tests/scheduler_test.rs
+++ b/mimium-cli/tests/scheduler_test.rs
@@ -15,9 +15,9 @@ fn scheduler_invalid() {
     let _ = run_file_with_scheduler("scheduler_invalid.mmm", 10);
 }
 
-// #[test]
-// fn scheduler_counter() {
-//     let res = run_file_with_scheduler("scheduler_counter.mmm", 10).unwrap();
-//     let ans = vec![0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0];
-//     assert_eq!(res, ans);
-// }
+#[test]
+fn scheduler_counter() {
+    let res = run_file_with_scheduler("scheduler_counter.mmm", 10).unwrap();
+    let ans = vec![0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0];
+    assert_eq!(res, ans);
+}

--- a/mimium-cli/tests/scheduler_test.rs
+++ b/mimium-cli/tests/scheduler_test.rs
@@ -21,3 +21,9 @@ fn scheduler_counter() {
     let ans = vec![0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0];
     assert_eq!(res, ans);
 }
+#[test]
+fn scheduler_counter_indirect() {
+    let res = run_file_with_scheduler("scheduler_counter_indirect.mmm", 10).unwrap();
+    let ans = vec![0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0];
+    assert_eq!(res, ans);
+}

--- a/mimium-lang/src/compiler/bytecodegen.rs
+++ b/mimium-lang/src/compiler/bytecodegen.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashMap};
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use crate::interner::{Symbol, TypeNodeId};
@@ -9,34 +9,10 @@ use crate::types::{PType, Type, TypeSize};
 use crate::utils::error::ReportableError;
 use vm::bytecode::Instruction as VmInstruction;
 
-#[derive(Debug, Clone, PartialEq)]
-enum Region {
-    Value(Arc<mir::Value>),
-    SubRegion(),
-}
-impl std::fmt::Display for Region {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Region::Value(v) => write!(f, "{}", v),
-            Region::SubRegion() => {
-                write!(f, "sub")
-            }
-        }
-    }
-}
 #[derive(Debug, Default)]
 struct MemoryRegion(Reg, TypeSize);
 #[derive(Debug, Default)]
 struct VRegister(HashMap<Arc<mir::Value>, MemoryRegion>);
-
-fn tostring_helper(vec: &[Option<Region>]) -> String {
-    vec[0..10].iter().fold("".to_string(), |s, a| {
-        format!(
-            "{s} {}",
-            a.clone().map_or("()".to_string(), |a| format!("{a}"))
-        )
-    })
-}
 
 impl VRegister {
     pub fn push_stack(&mut self, v: &Arc<mir::Value>, size: u64) -> Reg {
@@ -76,9 +52,6 @@ impl VRegister {
             }
             _ => None,
         }
-    }
-    pub fn find_range(&mut self, v: &Arc<mir::Value>, _size: usize) -> Option<Reg> {
-        self.find(v)
     }
     //find for load and store instruction
     pub fn find_keep(&self, v: &Arc<mir::Value>) -> Option<Reg> {
@@ -468,8 +441,8 @@ impl ByteCodeGenerator {
                     }
                     mir::Value::ExtFunction(label, ty) => {
                         let (dst, argsize, nret) =
-                        self.prepare_extcls(funcproto, bytecodes_dst, dst, args, *label, *ty);
-                    Some(VmInstruction::CallExtCls(dst, argsize, nret))
+                            self.prepare_extcls(funcproto, bytecodes_dst, dst, args, *label, *ty);
+                        Some(VmInstruction::CallExtCls(dst, argsize, nret))
                     }
                     _ => unreachable!(),
                 }

--- a/mimium-lang/src/compiler/bytecodegen.rs
+++ b/mimium-lang/src/compiler/bytecodegen.rs
@@ -449,10 +449,6 @@ impl ByteCodeGenerator {
                 let dst = self.get_destination(dst, 1);
                 Some(VmInstruction::Closure(dst, idx))
             }
-            mir::Instruction::ClosureRec => {
-                let dst = self.get_destination(dst, 1);
-                Some(VmInstruction::ClosureRec(dst))
-            }
             mir::Instruction::CloseUpValues(src, ty) => {
                 // src might contain multiple upvalues (e.g. tuple)
                 let flattened = ty.flatten();

--- a/mimium-lang/src/compiler/bytecodegen.rs
+++ b/mimium-lang/src/compiler/bytecodegen.rs
@@ -413,9 +413,6 @@ impl ByteCodeGenerator {
                             self.prepare_extfun(funcproto, bytecodes_dst, dst, args, *label, *r_ty);
                         Some(VmInstruction::CallExtFun(dst, argsize, nret))
                     }
-                    mir::Value::FixPoint(_) => {
-                        unreachable!("fixpoint should be called with callcls.")
-                    }
                     _ => unreachable!(),
                 }
             }

--- a/mimium-lang/src/compiler/bytecodegen.rs
+++ b/mimium-lang/src/compiler/bytecodegen.rs
@@ -452,6 +452,10 @@ impl ByteCodeGenerator {
                 let dst = self.get_destination(dst, 1);
                 Some(VmInstruction::Closure(dst, idx))
             }
+            mir::Instruction::ClosureRec => {
+                let dst = self.get_destination(dst, 1);
+                Some(VmInstruction::ClosureRec(dst))
+            }
             mir::Instruction::CloseUpValues(src, ty) => {
                 // src might contain multiple upvalues (e.g. tuple)
                 let flattened = ty.flatten();
@@ -779,7 +783,8 @@ mod test {
             0,
             Arc::new(mir::Argument("hoge".to_symbol(), numeric!())),
         ));
-        let mut func = mir::Function::new("test".to_symbol(), &[arg.clone()], &[numeric!()], None);
+        let mut func =
+            mir::Function::new(0, "test".to_symbol(), &[arg.clone()], &[numeric!()], None);
         func.return_type.get_or_init(|| numeric!());
         let mut block = mir::Block::default();
         let resint = Arc::new(mir::Value::Register(1));

--- a/mimium-lang/src/compiler/mirgen.rs
+++ b/mimium-lang/src/compiler/mirgen.rs
@@ -342,7 +342,6 @@ impl Context {
                             let currentf = self.program.functions.get_mut(current.func_i).unwrap();
                             let upi = currentf.get_or_insert_upvalue(&upv) as _;
                             let currentbb = currentf.body.get_mut(current.current_bb).unwrap();
-
                             currentbb
                                 .0
                                 .push((res.clone(), Instruction::GetUpValue(upi, t)));
@@ -352,7 +351,7 @@ impl Context {
             }
             LookupRes::Global(v) => match v.as_ref() {
                 Value::Global(_gv) => self.push_inst(Instruction::GetGlobal(v.clone(), t)),
-                Value::Function(_) | Value::Register(_)=> v.clone(),
+                Value::Function(_) | Value::Register(_) => v.clone(),
                 _ => unreachable!("non global_value"),
             },
             LookupRes::None => {
@@ -438,10 +437,6 @@ impl Context {
             .map(|a_meta| -> Result<_, CompileError> {
                 let (v, t) = self.eval_expr(*a_meta)?;
                 let res = match v.as_ref() {
-                    // for the higher order function, make closure regardless it is global function
-                    Value::Function(fn_i) if self.get_current_fn().index == *fn_i => {
-                        self.push_inst(Instruction::ClosureRec)
-                    }
                     Value::Function(idx) => {
                         let f = self.push_inst(Instruction::Uinteger(*idx as u64));
                         self.push_inst(Instruction::Closure(f))
@@ -544,16 +539,6 @@ impl Context {
                             Value::Register(_) => {
                                 self.push_inst(Instruction::CallCls(v.clone(), atvvec.clone(), rt))
                             }
-                            // Value::FixPoint(fnid) => {
-                            //     let cls = if self.get_current_fn().index == *fnid {
-                            //         self.push_inst(Instruction::ClosureRec)
-                            //     } else {
-                            //         let clspos =
-                            //             self.push_inst(Instruction::Uinteger(*fnid as u64));
-                            //         self.push_inst(Instruction::Closure(clspos))
-                            //     };
-                            //     self.push_inst(Instruction::CallCls(cls, atvvec.clone(), rt))
-                            // }
                             _ => {
                                 panic!("calling non-function global value")
                             }
@@ -563,15 +548,6 @@ impl Context {
                             //do not increment state size for closure
                             self.push_inst(Instruction::CallCls(f.clone(), atvvec.clone(), rt))
                         }
-                        // Value::FixPoint(fnid) => {
-                        //     let cls = if self.get_current_fn().index == *fnid {
-                        //         self.push_inst(Instruction::ClosureRec)
-                        //     } else {
-                        //         let clspos = self.push_inst(Instruction::Uinteger(*fnid as u64));
-                        //         self.push_inst(Instruction::Closure(clspos))
-                        //     };
-                        //     self.push_inst(Instruction::CallCls(cls, atvvec.clone(), rt))
-                        // }
                         Value::Function(idx) => self.emit_fncall(*idx as u64, atvvec.clone(), rt),
                         Value::ExtFunction(label, _ty) => {
                             if let Some(res) = self.make_intrinsics(*label, &atvvec)? {
@@ -702,23 +678,22 @@ impl Context {
                 }
             }
             Expr::LetRec(id, body, then) => {
+                let is_global = self.get_ctxdata().func_i == 0;
                 self.fn_label = Some(id.id);
                 let nextfunid = self.program.functions.len();
-                let fix = Arc::new(Value::Function(nextfunid));
-
-                // let alloc = self.push_inst(Instruction::Alloc(t.clone()));
-                // let _ = self.push_inst(Instruction::Store(alloc.clone(), fix));
-                let bind = (id.id, fix);
+                let t = self.typeenv.lookup_res(e);
+                let v = if is_global {
+                    Arc::new(Value::Function(nextfunid))
+                } else {
+                    let alloc = self.push_inst(Instruction::Alloc(t.clone()));
+                    alloc
+                };
+                let bind = (id.id, v.clone());
                 self.add_bind(bind);
                 let (b, _bt) = self.eval_expr(*body)?;
-                //set bind from fixpoint to computed lambda
-                let (_, v) = self
-                    .valenv
-                    .0
-                    .iter_mut()
-                    .find_map(|lenv| lenv.iter_mut().find(|(name, _)| *name == id.id))
-                    .unwrap();
-                *v = b;
+                if !is_global {
+                    let _ = self.push_inst(Instruction::Store(v.clone(), b.clone(), t));
+                }
                 if let Some(then_e) = then {
                     self.eval_expr(*then_e)
                 } else {

--- a/mimium-lang/src/compiler/parser.rs
+++ b/mimium-lang/src/compiler/parser.rs
@@ -282,14 +282,20 @@ fn statement_parser(
         .then_ignore(just(Token::Assign))
         .then(expr.clone())
         .map_with_span(|(ident, body), span| (Statement::Let(ident, body), span))
-        .labelled("let_stmt");
+        .labelled("let");
+    let letrec = just(Token::LetRec)
+        .ignore_then(lvar_parser_typed())
+        .then_ignore(just(Token::Assign))
+        .then(expr.clone())
+        .map_with_span(|(ident, body), span| (Statement::LetRec(ident, body), span))
+        .labelled("letrec");
     let assign = placement_parser()
         .then_ignore(just(Token::Assign))
         .then(expr.clone())
         .map_with_span(|(ident, body), span| (Statement::Assign(ident, body), span))
         .labelled("assign");
     let single = expr.map_with_span(|e, span| (Statement::Single(e), span));
-    let_.or(assign).or(single)
+    let_.or(letrec).or(assign).or(single)
 }
 fn statements_parser(
     expr: ExprParser<'_>,

--- a/mimium-lang/src/compiler/parser/lexer.rs
+++ b/mimium-lang/src/compiler/parser/lexer.rs
@@ -75,6 +75,7 @@ pub fn lexer() -> impl Parser<char, Vec<(Token, Span)>, Error = Simple<char>> {
         "self" => Token::SelfLit,
         "now" => Token::Now,
         "let" => Token::Let,
+        "letrec" => Token::LetRec,
         "if" => Token::If,
         "else" => Token::Else,
         // "true" => Token::Bool(true),
@@ -107,7 +108,7 @@ pub fn lexer() -> impl Parser<char, Vec<(Token, Span)>, Error = Simple<char>> {
         .map(|_s| Token::LineBreak);
     // A single token can be one of the above
     let token = comment_parser()
-        .map(|c| Token::Comment(c))
+        .map(Token::Comment)
         .or(float)
         .or(int)
         .or(str_)

--- a/mimium-lang/src/compiler/parser/test.rs
+++ b/mimium-lang/src/compiler/parser/test.rs
@@ -219,11 +219,14 @@ fn test_fndef() {
     let ans = Expr::LetRec(
         TypedId {
             ty: Type::Function(
-                vec![Type::Unknown.into_id(), Type::Unknown.into_id()],
-                Type::Unknown.into_id(),
+                vec![
+                    Type::Unknown.into_id_with_span(0..28),
+                    Type::Unknown.into_id_with_span(0..28),
+                ],
+                Type::Unknown.into_id_with_span(0..28),
                 None,
             )
-            .into_id(),
+            .into_id_with_span(0..28),
 
             id: "hoge".to_symbol(),
         },
@@ -249,26 +252,27 @@ fn test_fndef() {
 }
 #[test]
 fn global_fnmultiple() {
-    let fnty = function!(
-        vec![Type::Unknown.into_id(), Type::Unknown.into_id()],
-        Type::Unknown.into_id()
-    );
     let ans = Expr::LetRec(
         TypedId {
             id: "hoge".to_symbol(),
-            ty: fnty,
+            ty: Type::Function(
+                vec![
+                    Type::Unknown.into_id_with_span(0..28),
+                    Type::Unknown.into_id_with_span(0..28),
+                ],
+                Type::Unknown.into_id_with_span(0..28),
+                None,
+            )
+            .into_id_with_span(0..28),
         },
         Expr::Lambda(
-            vec![
-                TypedId {
-                    id: "input".to_symbol(),
-                    ty: Type::Unknown.into_id_with_span(8..13),
-                },
-                TypedId {
-                    id: "gue".to_symbol(),
-                    ty: Type::Unknown.into_id_with_span(14..17),
-                },
-            ],
+            vec![TypedId {
+                id: "input".to_symbol(),
+                ty: Type::Unknown.into_id_with_span(8..13),
+            },TypedId {
+                id: "gue".to_symbol(),
+                ty: Type::Unknown.into_id_with_span(14..17),
+            }],
             None,
             Expr::Var("input".to_symbol()).into_id(21..26),
         )
@@ -277,7 +281,15 @@ fn global_fnmultiple() {
             Expr::LetRec(
                 TypedId {
                     id: "hoge".to_symbol(),
-                    ty: fnty,
+                    ty: Type::Function(
+                        vec![
+                            Type::Unknown.into_id_with_span(29..57),
+                            Type::Unknown.into_id_with_span(29..57),
+                        ],
+                        Type::Unknown.into_id_with_span(29..57),
+                        None,
+                    )
+                    .into_id_with_span(29..57),
                 },
                 Expr::Lambda(
                     vec![
@@ -362,8 +374,8 @@ fn test_stmt_without_return() {
     let ans = Expr::LetRec(
         TypedId {
             id: "test".to_symbol(),
-            ty: Type::Function(vec![Type::Unknown.into_id()], Type::Unknown.into_id(), None)
-                .into_id(),
+            ty: Type::Function(vec![Type::Unknown.into_id_with_span(0..56)], Type::Unknown.into_id_with_span(0..56), None)
+                .into_id_with_span(0..56),
         },
         Expr::Lambda(
             vec![TypedId {

--- a/mimium-lang/src/compiler/parser/token.rs
+++ b/mimium-lang/src/compiler/parser/token.rs
@@ -61,6 +61,7 @@ pub enum Token {
     SemiColon,
 
     Let,
+    LetRec,
     Assign,
 
     Reference, //?
@@ -160,6 +161,7 @@ impl fmt::Display for Token {
             Token::Colon => write!(f, ":"),
             Token::SemiColon => write!(f, ";"),
             Token::Let => write!(f, "let"),
+            Token::LetRec => write!(f, "letrec"),
             Token::Assign => write!(f, "="),
             Token::Reference => write!(f, "&"),
             Token::ParenBegin => write!(f, "("),

--- a/mimium-lang/src/compiler/typing.rs
+++ b/mimium-lang/src/compiler/typing.rs
@@ -16,7 +16,8 @@ use std::rc::Rc;
 pub enum ErrorKind {
     TypeMismatch(Type, Type),
     PatternMismatch(Type, Pattern),
-    NonFunction(Type),
+    NonFunctionForLetRec(Type),
+    NonFunctionForApply(Type),
     CircularType,
     IndexOutOfRange(u16, u16),
     IndexForNonTuple,
@@ -45,7 +46,14 @@ impl fmt::Display for ErrorKind {
             ErrorKind::NonPrimitiveInFeed => {
                 write!(f, "Function that uses self cannot be return function type.")
             }
-            ErrorKind::NonFunction(t) => write!(f, "{t} is not a function type."),
+            ErrorKind::NonFunctionForApply(t) => write!(
+                f,
+                "{t} is not applicable because it is not a function type."
+            ),
+            ErrorKind::NonFunctionForLetRec(t) => write!(
+                f,
+                "\"letrec\" requires the expression to be function type but it was {t} type."
+            ),
         }
     }
 }
@@ -419,11 +427,15 @@ impl InferContext {
                 }
             }
             Expr::LetRec(id, body, then) => {
-                let idt = match (id.is_unknown(), id.ty.to_type()) {
+                let t = id.ty.to_type();
+                let idt = match (id.is_unknown(), &t) {
                     (false, Type::Function(atypes, rty, s)) => {
-                        self.convert_unknown_function(&atypes, rty, s)
+                        self.convert_unknown_function(atypes, *rty, *s)
                     }
-                    _ => panic!("type for letrec is limited to function type in mimium."),
+                    (false, _) => {
+                        return Err(Error(ErrorKind::NonFunctionForLetRec(t.clone()), span))
+                    }
+                    (true, _) => self.gen_intermediate_type(),
                 };
 
                 let body_i = self.gen_intermediate_type();
@@ -457,7 +469,7 @@ impl InferContext {
                     Ok(r)
                 } else {
                     Err(Error(
-                        ErrorKind::NonFunction(restype.to_type().clone()),
+                        ErrorKind::NonFunctionForApply(restype.to_type().clone()),
                         span.clone(),
                     ))
                 }

--- a/mimium-lang/src/mir.rs
+++ b/mimium-lang/src/mir.rs
@@ -24,7 +24,6 @@ pub enum Value {
     // idx of the function in the program
     Function(usize),
     ExtFunction(Symbol, TypeNodeId),
-    FixPoint(usize), //function id
     //internal state
     None,
 }

--- a/mimium-lang/src/mir.rs
+++ b/mimium-lang/src/mir.rs
@@ -57,7 +57,6 @@ pub enum Instruction {
     SetGlobal(VPtr, VPtr, TypeNodeId),
     // make closure with upindexes
     Closure(VPtr),
-    ClosureRec,
     //closes upvalues of specific closure. Always inserted right before Return instruction.
     CloseUpValues(VPtr, TypeNodeId),
     //label to funcproto  and localvar offset?

--- a/mimium-lang/src/mir.rs
+++ b/mimium-lang/src/mir.rs
@@ -58,6 +58,7 @@ pub enum Instruction {
     SetGlobal(VPtr, VPtr, TypeNodeId),
     // make closure with upindexes
     Closure(VPtr),
+    ClosureRec,
     //closes upvalues of specific closure. Always inserted right before Return instruction.
     CloseUpValues(VPtr, TypeNodeId),
     //label to funcproto  and localvar offset?
@@ -138,6 +139,7 @@ pub struct OpenUpValue(pub usize, pub TypeSize);
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Function {
+    pub index: usize,
     pub label: Symbol,
     pub args: Vec<Arc<Value>>,
     pub argtypes: Vec<TypeNodeId>,
@@ -156,12 +158,14 @@ pub struct StateSize {
 
 impl Function {
     pub fn new(
+        index: usize,
         name: Symbol,
         args: &[VPtr],
         argtypes: &[TypeNodeId],
         upperfn_i: Option<usize>,
     ) -> Self {
         Self {
+            index,
             label: name,
             args: args.to_vec(),
             argtypes: argtypes.to_vec(),

--- a/mimium-lang/src/mir/print.rs
+++ b/mimium-lang/src/mir/print.rs
@@ -125,9 +125,6 @@ impl std::fmt::Display for Instruction {
                     write!(f, "closure {}", *fun)
                 }
             }
-            Instruction::ClosureRec => {
-                write!(f, "closurerec")
-            }
             Instruction::CloseUpValues(cls, ty) => {
                 write!(f, "close {} {}", *cls, ty.to_type())
             }

--- a/mimium-lang/src/mir/print.rs
+++ b/mimium-lang/src/mir/print.rs
@@ -126,6 +126,9 @@ impl std::fmt::Display for Instruction {
                     write!(f, "closure {}", *fun)
                 }
             }
+            Instruction::ClosureRec => {
+                write!(f, "closurerec")
+            }
             Instruction::CloseUpValues(cls, ty) => {
                 write!(f, "close {} {}", *cls, ty.to_type())
             }

--- a/mimium-lang/src/mir/print.rs
+++ b/mimium-lang/src/mir/print.rs
@@ -69,7 +69,6 @@ impl std::fmt::Display for Value {
             Value::Register(r) => write!(f, "reg({r})"),
             Value::Function(id) => write!(f, "function {id}"),
             Value::ExtFunction(label, t) => write!(f, "extfun {label} {}", t.to_type()),
-            Value::FixPoint(i) => write!(f, "fixpoint {i}"),
             Value::State(v) => write!(f, "state({})", *v),
             Value::None => write!(f, "none"),
         }

--- a/mimium-lang/src/runtime/vm.rs
+++ b/mimium-lang/src/runtime/vm.rs
@@ -476,12 +476,14 @@ impl Machine {
     }
     #[allow(clippy::filter_map_bool_then)]
     fn release_open_closures(&mut self, local_closures: &[ClosureIdx]) {
-        for clsidx in local_closures.iter() {
-            let cls = self.get_closure(*clsidx);
-            if !cls.is_closed {
-                self.closures.remove(clsidx.0);
-            }
-        }
+        // for clsidx in local_closures.iter() {
+        //     let cls = self.get_closure(*clsidx);
+        //     if !cls.is_closed {
+        //         log::debug!("release {:?}", clsidx);
+
+        //         self.closures.remove(clsidx.0);
+        //     }
+        // }
     }
     /// Execute function, return retcode.
     pub fn execute(
@@ -533,6 +535,7 @@ impl Machine {
                 Instruction::CallCls(func, nargs, nret_req) => {
                     let addr = self.get_stack(func as i64);
                     let cls_i = Self::get_as::<ClosureIdx>(addr);
+                    log::debug!("callcls {:?}", cls_i);
                     let cls = self.get_closure(cls_i);
                     let pos_of_f = cls.fn_proto_pos;
                     self.states_stack.push(cls_i);
@@ -577,6 +580,8 @@ impl Machine {
                         fn_proto_pos,
                         &mut upv_map,
                     )));
+                    log::debug!("alloc {:?}", vaddr);
+
                     local_closures.push(vaddr);
                     self.set_stack(dst as i64, Self::to_value(vaddr));
                 }

--- a/mimium-lang/src/runtime/vm.rs
+++ b/mimium-lang/src/runtime/vm.rs
@@ -476,6 +476,8 @@ impl Machine {
     }
     #[allow(clippy::filter_map_bool_then)]
     fn release_open_closures(&mut self, local_closures: &[ClosureIdx]) {
+        //currently disabled until correct garbage collection is implemented!
+
         // for clsidx in local_closures.iter() {
         //     let cls = self.get_closure(*clsidx);
         //     if !cls.is_closed {
@@ -584,9 +586,6 @@ impl Machine {
 
                     local_closures.push(vaddr);
                     self.set_stack(dst as i64, Self::to_value(vaddr));
-                }
-                Instruction::ClosureRec(dst) => {
-                    self.set_stack(dst as i64, Self::to_value(cls_i.unwrap()));
                 }
                 Instruction::Close(src) => {
                     self.close_upvalues(src);

--- a/mimium-lang/src/runtime/vm.rs
+++ b/mimium-lang/src/runtime/vm.rs
@@ -537,7 +537,6 @@ impl Machine {
                 Instruction::CallCls(func, nargs, nret_req) => {
                     let addr = self.get_stack(func as i64);
                     let cls_i = Self::get_as::<ClosureIdx>(addr);
-                    log::debug!("callcls {:?}", cls_i);
                     let cls = self.get_closure(cls_i);
                     let pos_of_f = cls.fn_proto_pos;
                     self.states_stack.push(cls_i);
@@ -582,7 +581,6 @@ impl Machine {
                         fn_proto_pos,
                         &mut upv_map,
                     )));
-                    log::debug!("alloc {:?}", vaddr);
 
                     local_closures.push(vaddr);
                     self.set_stack(dst as i64, Self::to_value(vaddr));
@@ -846,7 +844,6 @@ impl Machine {
         self.scheduler.set_cur_time(now);
 
         if let Some(task_cls) = self.scheduler.pop_task(now, prog) {
-            log::debug!("task id {:?}", task_cls);
             let closure = self.get_closure(task_cls);
             self.execute(closure.fn_proto_pos, prog, Some(task_cls));
             // self.closures.remove(task_cls.0);

--- a/mimium-lang/src/runtime/vm.rs
+++ b/mimium-lang/src/runtime/vm.rs
@@ -585,6 +585,9 @@ impl Machine {
                     local_closures.push(vaddr);
                     self.set_stack(dst as i64, Self::to_value(vaddr));
                 }
+                Instruction::ClosureRec(dst) => {
+                    self.set_stack(dst as i64, Self::to_value(cls_i.unwrap()));
+                }
                 Instruction::Close(src) => {
                     self.close_upvalues(src);
                 }

--- a/mimium-lang/src/runtime/vm/bytecode.rs
+++ b/mimium-lang/src/runtime/vm/bytecode.rs
@@ -26,8 +26,6 @@ pub enum Instruction {
     CallExtCls(Reg, u8, TypeSize),
     // destination, index of inner function prototype in global function table.
     Closure(Reg, Reg),
-    // Recursive closure(mainly used for temporal recursion), destination
-    ClosureRec(Reg),
     // register of the closure to be closed. other local closures will be released with this instruction.
     Close(Reg),
     //destination,source, size
@@ -121,9 +119,6 @@ impl std::fmt::Display for Instruction {
 
             Instruction::Closure(dst, src) => {
                 write!(f, "{:<10} {} {}", "closure", dst, src)
-            }
-            Instruction::ClosureRec(dst) => {
-                write!(f, "{:<10} {}", "closurerec", dst)
             }
             Instruction::Close(src) => {
                 write!(f, "{:<10} {}", "close", src)

--- a/mimium-lang/src/runtime/vm/bytecode.rs
+++ b/mimium-lang/src/runtime/vm/bytecode.rs
@@ -26,6 +26,8 @@ pub enum Instruction {
     CallExtCls(Reg, u8, TypeSize),
     // destination, index of inner function prototype in global function table.
     Closure(Reg, Reg),
+    // Recursive closure(mainly used for temporal recursion), destination
+    ClosureRec(Reg),
     // register of the closure to be closed. other local closures will be released with this instruction.
     Close(Reg),
     //destination,source, size
@@ -119,6 +121,9 @@ impl std::fmt::Display for Instruction {
 
             Instruction::Closure(dst, src) => {
                 write!(f, "{:<10} {} {}", "closure", dst, src)
+            }
+            Instruction::ClosureRec(dst) => {
+                write!(f, "{:<10} {}", "closurerec", dst)
             }
             Instruction::Close(src) => {
                 write!(f, "{:<10} {}", "close", src)

--- a/mimium-lang/src/runtime/vm/test.rs
+++ b/mimium-lang/src/runtime/vm/test.rs
@@ -250,19 +250,22 @@ fn prep_closure_gc_program(is_closed: bool) -> Program {
     };
     prog
 }
-#[test]
-fn closure_gc_open() {
-    let prog = prep_closure_gc_program(false);
-    let mut machine: Machine = Machine::new_without_scheduler();
-    machine.execute_main(&prog);
-    //open closure should be released.
-    assert_eq!(machine.closures.len(), 0);
-}
-#[test]
-fn closure_gc_closed() {
-    let prog = prep_closure_gc_program(true);
-    let mut machine: Machine = Machine::new_without_scheduler();
-    machine.execute_main(&prog);
-    //closed closure should be kept.
-    assert_eq!(machine.closures.len(), 1);
-}
+
+// closure gc is disabled until correct implementation comes.
+
+// #[test]
+// fn closure_gc_open() {
+//     let prog = prep_closure_gc_program(false);
+//     let mut machine: Machine = Machine::new_without_scheduler();
+//     machine.execute_main(&prog);
+//     //open closure should be released.
+//     assert_eq!(machine.closures.len(), 0);
+// }
+// #[test]
+// fn closure_gc_closed() {
+//     let prog = prep_closure_gc_program(true);
+//     let mut machine: Machine = Machine::new_without_scheduler();
+//     machine.execute_main(&prog);
+//     //closed closure should be kept.
+//     assert_eq!(machine.closures.len(), 1);
+// }


### PR DESCRIPTION
Currently, recursive function can only be defined through `fn hoge(args) { expr }` syntax, which is a syntactic sugar to `letrec hoge = |args| {expr}` though the `letrec` cannot be allowed to parse, and `fn` syntax cannot be nested.
In this PR, we add a direct expression of `letrec` syntax to allow defining a recursive function inside function.


```rust
fn makecounter(){
    let x = 0.0
    letrec gen = | |{
        x = x+1.0
        gen@now+1.0
    }
    gen@1.0
    let getter = | | {x}
    getter
}
let x_getter = makecounter();
fn dsp(){
    x_getter()
}
```