### PR TITLE
Improve type mismatch error

### DIFF
--- a/mimium-lang/src/compiler/parser/test.rs
+++ b/mimium-lang/src/compiler/parser/test.rs
@@ -196,9 +196,9 @@ fn test_applynested() {
             Expr::Var("myfun2".to_symbol()).into_id(6..12),
             vec![Expr::Var("callee".to_symbol()).into_id(13..19)],
         )
-        .into_id(6..19)],
+        .into_id(6..20)],
     )
-    .into_id(0..19);
+    .into_id(0..20);
     test_string!("myfun(myfun2(callee))", ans);
 }
 #[test]
@@ -390,7 +390,7 @@ fn test_stmt_without_return() {
                             Expr::Var("print".to_symbol()).into_id(40..45),
                             vec![Expr::Var("v".to_symbol()).into_id(46..47)],
                         )
-                        .into_id(40..47),
+                        .into_id(40..48),
                         Some(Expr::Var("v".to_symbol()).into_id(53..54)),
                     )
                     .into_id(40..54),

--- a/mimium-lang/src/compiler/typing.rs
+++ b/mimium-lang/src/compiler/typing.rs
@@ -212,18 +212,18 @@ impl InferContext {
         })
     }
 
-    fn unify_types(t1: TypeNodeId, t2: TypeNodeId) -> Result<TypeNodeId, Error> {
+    fn unify_types(t1: TypeNodeId, t2: TypeNodeId, span: Span) -> Result<TypeNodeId, Error> {
         let unify_vec = |a1: &[TypeNodeId], a2: &[TypeNodeId]| -> Result<Vec<_>, Error> {
             if a1.len() != a2.len() {
                 return Err(Error(
                     ErrorKind::TypeMismatch(t1.to_type(), t2.to_type()),
-                    t1.to_span(),
+                    span.clone(),
                 ));
             }
 
             a1.iter()
                 .zip(a2.iter())
-                .map(|(v1, v2)| Self::unify_types(*v1, *v2))
+                .map(|(v1, v2)| Self::unify_types(*v1, *v2, span.clone()))
                 .try_collect()
         };
         log::trace!("unify {} and {}", t1.to_type(), t2.to_type());
@@ -267,16 +267,20 @@ impl InferContext {
                 Ok(t1r)
             }
             (Type::Array(a1), Type::Array(a2)) => {
-                Ok(Type::Array(Self::unify_types(*a1, *a2)?).into_id())
+                Ok(Type::Array(Self::unify_types(*a1, *a2, span)?).into_id())
             }
-            (Type::Ref(x1), Type::Ref(x2)) => Ok(Type::Ref(Self::unify_types(*x1, *x2)?).into_id()),
-            (Type::Tuple(a1), Type::Tuple(a2)) => Ok(Type::Tuple(unify_vec(a1, a2)?).into_id()),
+            (Type::Ref(x1), Type::Ref(x2)) => {
+                Ok(Type::Ref(Self::unify_types(*x1, *x2, span)?).into_id())
+            }
+            (Type::Tuple(a1), Type::Tuple(a2)) => {
+                Ok(Type::Tuple(unify_vec(a1, a2)?).into_id_with_span(span))
+            }
             (Type::Struct(_a1), Type::Struct(_a2)) => todo!(), //todo
             (Type::Function(p1, r1, s1), Type::Function(p2, r2, s2)) => Ok(Type::Function(
                 unify_vec(p1, p2)?,
-                Self::unify_types(*r1, *r2)?,
+                Self::unify_types(*r1, *r2, span.clone())?,
                 match (s1, s2) {
-                    (Some(e1), Some(e2)) => Some(Self::unify_types(*e1, *e2)?),
+                    (Some(e1), Some(e2)) => Some(Self::unify_types(*e1, *e2, span)?),
                     (None, None) => None,
                     (_, _) => todo!("error handling"),
                 },
@@ -289,12 +293,20 @@ impl InferContext {
             (Type::Code(_p1), Type::Code(_p2)) => {
                 todo!("type system for multi-stage computation has not implemented yet")
             }
-            (p1, p2) => Err(Error(ErrorKind::TypeMismatch(p1.clone(), p2.clone()), 0..0)), //todo:span
+            (p1, p2) => Err(Error(ErrorKind::TypeMismatch(p1.clone(), p2.clone()), span)),
         }
     }
-    fn bind_pattern(&mut self, t: TypeNodeId, ty_pat: &TypedPattern) -> Result<TypeNodeId, Error> {
+    // Note: the third argument `span` is used for the error location in case of
+    // type mismatch. This is needed because `t`'s span refers to the location
+    // where it originally defined (e.g. the explicit return type of the
+    // function) and is not necessarily the same as where the error happens.
+    fn bind_pattern(
+        &mut self,
+        t: TypeNodeId,
+        ty_pat: &TypedPattern,
+        span: Span,
+    ) -> Result<TypeNodeId, Error> {
         let TypedPattern { pat, .. } = ty_pat;
-        let span = ty_pat.to_span();
         let pat_t = match pat {
             Pattern::Single(id) => {
                 self.env.add_bind(&[(*id, t)]);
@@ -304,18 +316,18 @@ impl InferContext {
                 let res = pats
                     .iter()
                     .map(|p| {
-                        let ity = self.gen_intermediate_type_with_span(span.clone());
+                        let ity = self.gen_intermediate_type_with_span(ty_pat.to_span());
                         let p = TypedPattern {
                             pat: p.clone(),
                             ty: ity,
                         };
-                        self.bind_pattern(ity, &p)
+                        self.bind_pattern(ity, &p, span.clone())
                     })
                     .try_collect::<Vec<_>>()?;
                 Ok(Type::Tuple(res).into_id())
             }
         }?;
-        Self::unify_types(t, pat_t)
+        Self::unify_types(t, pat_t, span)
     }
 
     pub fn lookup(&self, name: &Symbol, span: &Span) -> Result<TypeNodeId, Error> {
@@ -367,7 +379,7 @@ impl InferContext {
                 let feedv = self.gen_intermediate_type();
                 self.env.add_bind(&[(*id, feedv)]);
                 let b = self.infer_type(*body)?;
-                let res = Self::unify_types(b, feedv)?;
+                let res = Self::unify_types(b, feedv, span)?;
                 if res.to_type().contains_function() {
                     Err(Error(ErrorKind::NonPrimitiveInFeed, body.to_span().clone()))
                 } else {
@@ -390,7 +402,7 @@ impl InferContext {
                     .collect();
                 let bty = if let Some(r) = rtype {
                     let bty = self.infer_type(*body)?;
-                    Self::unify_types(*r, bty)?
+                    Self::unify_types(*r, bty, body.to_span())?
                 } else {
                     self.infer_type(*body)?
                 };
@@ -410,8 +422,8 @@ impl InferContext {
                     self.gen_intermediate_type()
                 };
 
-                let bodyt_u = Self::unify_types(idt, bodyt)?;
-                let _ = self.bind_pattern(bodyt_u, tpat)?;
+                let bodyt_u = Self::unify_types(idt, bodyt, body.to_span())?;
+                let _ = self.bind_pattern(bodyt_u, tpat, body.to_span())?;
 
                 match then {
                     Some(e) => self.infer_type(*e),
@@ -429,7 +441,7 @@ impl InferContext {
                 let body_i = self.gen_intermediate_type();
                 self.env.add_bind(&[(id.id, body_i)]);
                 let bodyt = self.infer_type(*body)?;
-                let _ = Self::unify_types(idt, bodyt)?;
+                let _ = Self::unify_types(idt, bodyt, body.to_span())?;
 
                 match then {
                     Some(e) => self.infer_type(*e),
@@ -439,7 +451,7 @@ impl InferContext {
             Expr::Assign(name, expr) => {
                 let assignee_t = self.lookup(name, &span)?;
                 let e_t = self.infer_type(*expr)?;
-                Self::unify_types(assignee_t, e_t)?;
+                Self::unify_types(assignee_t, e_t, expr.to_span())?;
                 Ok(unit!())
             }
             Expr::Then(e, then) => {
@@ -452,7 +464,7 @@ impl InferContext {
                 let callee_t = self.infer_vec(callee.as_slice())?;
                 let res_t = self.gen_intermediate_type();
                 let fntype = Type::Function(callee_t, res_t, None).into_id();
-                let restype = Self::unify_types(fnl, fntype)?;
+                let restype = Self::unify_types(fnl, fntype, span.clone())?;
                 if let Type::Function(_, r, _) = restype.to_type() {
                     Ok(r)
                 } else {
@@ -464,12 +476,18 @@ impl InferContext {
             }
             Expr::If(cond, then, opt_else) => {
                 let condt = self.infer_type(*cond)?;
-                let _bt = Self::unify_types(Type::Primitive(PType::Numeric).into_id(), condt); //todo:boolean type
+                let cond_span = cond.to_span();
+                let _bt = Self::unify_types(
+                    Type::Primitive(PType::Numeric).into_id_with_span(cond_span.clone()),
+                    condt,
+                    cond_span,
+                ); //todo:boolean type
                 let thent = self.infer_type(*then)?;
                 let elset = opt_else.map_or(Ok(Type::Primitive(PType::Unit).into_id()), |e| {
                     self.infer_type(e)
                 })?;
-                Self::unify_types(thent, elset)
+                let else_span = opt_else.map_or(span.end..span.end, |e| e.to_span());
+                Self::unify_types(thent, elset, else_span)
             }
             Expr::Block(expr) => expr.map_or(Ok(Type::Primitive(PType::Unit).into_id()), |e| {
                 self.infer_type(e)

--- a/mimium-lang/src/compiler/typing.rs
+++ b/mimium-lang/src/compiler/typing.rs
@@ -29,8 +29,17 @@ pub struct Error(pub ErrorKind, pub Span);
 impl fmt::Display for ErrorKind {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match &self {
-            ErrorKind::TypeMismatch(e, a) => write!(f, "Type Mismatch, between {e} and {a}"),
-            ErrorKind::PatternMismatch(e, p) => write!(f, "Pattern {p} cannot have {e} type."),
+            ErrorKind::TypeMismatch(e, a) => write!(
+                f,
+                "Type Mismatch, between {} and {}",
+                e.to_string_for_error(),
+                a.to_string_for_error()
+            ),
+            ErrorKind::PatternMismatch(e, p) => write!(
+                f,
+                "Pattern {p} cannot have {} type.",
+                e.to_string_for_error()
+            ),
 
             ErrorKind::CircularType => write!(f, "Circular loop of type definition"),
             ErrorKind::IndexOutOfRange(len, idx) => write!(
@@ -45,7 +54,9 @@ impl fmt::Display for ErrorKind {
             ErrorKind::NonPrimitiveInFeed => {
                 write!(f, "Function that uses self cannot be return function type.")
             }
-            ErrorKind::NonFunction(t) => write!(f, "{t} is not a function type."),
+            ErrorKind::NonFunction(t) => {
+                write!(f, "{} is not a function type.", t.to_string_for_error())
+            }
         }
     }
 }

--- a/mimium-lang/src/types.rs
+++ b/mimium-lang/src/types.rs
@@ -110,6 +110,50 @@ impl Type {
     pub fn into_id_with_span(self, span: Span) -> TypeNodeId {
         with_session_globals(|session_globals| session_globals.store_type_with_span(self, span))
     }
+
+    pub fn to_string_for_error(&self) -> String {
+        match self {
+            Type::Array(a) => {
+                format!("[{}, ...]", a.to_type().to_string_for_error())
+            }
+            Type::Tuple(v) => {
+                let vf = format_vec!(
+                    v.iter()
+                        .map(|x| x.to_type().to_string_for_error())
+                        .collect::<Vec<_>>(),
+                    ","
+                );
+                format!("({vf})")
+            }
+            Type::Struct(v) => {
+                let vf = format_vec!(
+                    v.iter()
+                        .map(|(s, x)| format!(
+                            "{}: {}",
+                            s.as_str(),
+                            x.to_type().to_string_for_error()
+                        ))
+                        .collect::<Vec<_>>(),
+                    ","
+                );
+                format!("({vf})")
+            }
+            Type::Function(p, r, _s) => {
+                let args = format_vec!(
+                    p.iter()
+                        .map(|x| x.to_type().to_string_for_error())
+                        .collect::<Vec<_>>(),
+                    ","
+                );
+                format!("({args})->{}", r.to_type().to_string_for_error())
+            }
+            Type::Ref(x) => format!("&{}", x.to_type().to_string_for_error()),
+            Type::Code(c) => "<...code...>".to_string(),
+            Type::Intermediate(id) => "?".to_string(),
+            // if no special treatment is needed, forward to the Display implementation
+            x => x.to_string(),
+        }
+    }
 }
 
 impl TypeNodeId {


### PR DESCRIPTION
This pull request is to improve error messages of `ErrorKind::TypeMismatch`. The current error message is a bit confusing because the span of the actual error location is not propagated.

**Code:**

```
let unrelated = 0.0

fn foo() -> float{
    1.0
}
fn dsp(){
    let (x, y) = foo()
    x
}
```

**Error message:**

```
   ╭─[../path/to/tmp.mmm:7:18]
   │
 1 │ let unrelated = 0.0
   · │
   · ╰─ Type Mismatch, between number and (i(3()),i(4()))
───╯
```

This pull request improves this *to some extent* by the following changes:

1. Explicitly propagate the appropriate `span`.
2. Improve the parser to include the span of `( )` in `Apply`.
3. Show user friendly message like `(?,?)` instead of `(i(3()),i(4()))`.

The error message will look like this:

```
   ╭─[../path/to/tmp.mmm:7:18]
   │
 7 │     let (x, y) = foo()
   ·                  ──┬──
   ·                    ╰──── Type Mismatch, between number and (?,?)
───╯
```

---

Some thoughts:

* This pull request is not intended to be complete. This addresses only a few of the cases. I hope we can improve the error message step by step.
* Probably, `Type::into_id()` should take `span`. It's hard to track where the span is replaced with `0..0`. It might be hard to figure out what span is appropriate, but I'm feeling any span is better than `0..0`.
* The explicit propagation was needed because the `Span` corresponding to a `Type` might not be appropriate for the error message. For example, when I attempted to store the `Span` and use it, I got the following error message. Apparently, `foo()`'s type is determined by the `-> float` annotation, but we expect `let (x, y) = foo()` is where the error happens.

```
   ╭─[../path/to/tmp.mmm:7:18]
   │
 3 │ fn foo() -> float{
   ·             ──┬──
   ·               ╰──── Type Mismatch, between number and (i(3()),i(4()))
───╯
```