### PR TITLE
chore: update ariadne to 0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,10 +101,11 @@ dependencies = [
 
 [[package]]
 name = "ariadne"
-version = "0.1.5"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1cb2a2046bea8ce5e875551f5772024882de0b540c7f93dfc5d6cf1ca8b030c"
+checksum = "44055e597c674aef7cb903b2b9f6e4cba1277ed0d2d61dae7cd52d7ffa81f8e2"
 dependencies = [
+ "unicode-width",
  "yansi",
 ]
 
@@ -889,6 +890,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1262,9 +1269,9 @@ dependencies = [
 
 [[package]]
 name = "yansi"
-version = "0.5.1"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "zerocopy"

--- a/mimium-lang/Cargo.toml
+++ b/mimium-lang/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 [dependencies]
 
 chumsky = "0.9"
-ariadne = "0.1.5"
+ariadne = "0.4"
 log = "0.4.22"
 string-interner = "0.17.0"
 slotmap = "1.0.7"


### PR DESCRIPTION
For some reason, mimium uses a bit outdated version of ariadne. It seems there's no significant change in the changelog, so this isn't something very urgent. Mostly just for house keeping.

cf. https://github.com/zesterer/ariadne/blob/main/CHANGELOG.md