### PR TITLE
Implement `include` preprocessor

### DIFF
--- a/mimium-cli/src/main.rs
+++ b/mimium-cli/src/main.rs
@@ -59,8 +59,8 @@ pub struct Mode {
     pub emit_bytecode: bool,
 }
 
-fn emit_ast_local(src: &str) -> Result<ExprNodeId, Vec<Box<dyn ReportableError>>> {
-    let ast1 = emit_ast(src)?;
+fn emit_ast_local(src: &str, filepath: &Path) -> Result<ExprNodeId, Vec<Box<dyn ReportableError>>> {
+    let ast1 = emit_ast(src, Some(filepath.to_str().unwrap().to_symbol()))?;
 
     convert_pronoun::convert_pronoun(ast1).map_err(|e| {
         let eb: Vec<Box<dyn ReportableError>> = vec![Box::new(e)];
@@ -117,7 +117,7 @@ fn run_file(
     let path_sym = fullpath.to_string_lossy().to_symbol();
     let mut ctx = get_default_context(Some(path_sym));
     if args.mode.emit_ast {
-        let ast = emit_ast_local(content)?;
+        let ast = emit_ast_local(content, fullpath)?;
         println!("{}", ast.pretty_print());
     } else if args.mode.emit_mir {
         ctx.prepare_compiler();

--- a/mimium-cli/src/main.rs
+++ b/mimium-cli/src/main.rs
@@ -80,7 +80,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = Args::parse();
     match &args.file {
         Some(file) => {
-            let (content, fullpath) = fileloader::load(file.clone())?;
+            let fullpath = fileloader::get_canonical_path(".", &file)?;
+            let content = fileloader::load(fullpath.to_str().unwrap())?;
             match run_file(&args, &content, &fullpath) {
                 Ok(_) => {}
                 Err(e) => {

--- a/mimium-lang/src/compiler.rs
+++ b/mimium-lang/src/compiler.rs
@@ -66,6 +66,8 @@ impl ReportableError for Error {
     }
 }
 
+use std::path::PathBuf;
+
 use mirgen::recursecheck;
 
 use crate::{
@@ -76,8 +78,12 @@ use crate::{
     types::Type,
     utils::{error::ReportableError, metadata::Span},
 };
-pub fn emit_ast(src: &str) -> Result<ExprNodeId, Vec<Box<dyn ReportableError>>> {
-    let ast = parser::parse(src).map(|ast| parser::add_global_context(ast))?;
+pub fn emit_ast(
+    src: &str,
+    filepath: Option<Symbol>,
+) -> Result<ExprNodeId, Vec<Box<dyn ReportableError>>> {
+    let ast = parser::parse(src, filepath.map(|sym| PathBuf::from(sym.to_string())))
+        .map(|ast| parser::add_global_context(ast))?;
     Ok(recursecheck::convert_recurse(ast))
 }
 #[derive(Clone, Copy)]
@@ -109,7 +115,11 @@ impl Context {
             .collect()
     }
     pub fn emit_mir(&self, src: &str) -> Result<Mir, Vec<Box<dyn ReportableError>>> {
-        let ast = parser::parse(src).map(|ast| parser::add_global_context(ast))?;
+        let ast = parser::parse(
+            src,
+            self.file_path.map(|sym| PathBuf::from(sym.to_string())),
+        )
+        .map(|ast| parser::add_global_context(ast))?;
 
         mirgen::compile(ast, &self.get_ext_typeinfos(), self.file_path).map_err(|e| {
             let bres = e as Box<dyn ReportableError>;
@@ -126,7 +136,7 @@ pub fn interpret_top(
     content: String,
     global_ctx: &mut ast_interpreter::Context,
 ) -> Result<ast_interpreter::Value, Vec<Box<dyn ReportableError>>> {
-    let ast = emit_ast(&content)?;
+    let ast = emit_ast(&content,None)?;
     ast_interpreter::eval_ast(ast, global_ctx).map_err(|e| {
         let eb: Box<dyn ReportableError> = Box::new(e);
         vec![eb]

--- a/mimium-lang/src/compiler/parser/lexer.rs
+++ b/mimium-lang/src/compiler/parser/lexer.rs
@@ -85,6 +85,7 @@ pub fn lexer() -> impl Parser<char, Vec<(Token, Span)>, Error = Simple<char>> {
         "int" => Token::IntegerType,
         "string" => Token::StringType,
         "struct" => Token::StructType,
+        "include" => Token::Include,
         "_" => Token::PlaceHolder,
         _ => Token::Ident(ident.to_symbol()),
     });

--- a/mimium-lang/src/compiler/parser/resolve_include.rs
+++ b/mimium-lang/src/compiler/parser/resolve_include.rs
@@ -1,7 +1,20 @@
+use super::{parse, Span};
 use crate::interner::ExprNodeId;
+use crate::utils::error::{ReportableError, ReportableErrorDyn};
+use crate::utils::fileloader;
 
-pub struct Error{}
-
-pub fn resolve_include(file_path:&str)->Result<ExprNodeId,Error>{
-    todo!()
+pub(super) fn resolve_include(
+    mmm_filepath: &str,
+    target_path: &str,
+    span: Span,
+) -> Result<ExprNodeId, Vec<Box<dyn ReportableError>>> {
+    let make_err = |e: fileloader::Error| {
+        vec![Box::new(ReportableErrorDyn {
+            message: e.to_string(),
+            span: span.clone(),
+        }) as Box<dyn ReportableError>]
+    };
+    let abspath = fileloader::get_canonical_path(mmm_filepath, target_path).map_err(make_err)?;
+    let content = fileloader::load(abspath.to_str().unwrap()).map_err(make_err)?;
+    parse(&content, Some(abspath))
 }

--- a/mimium-lang/src/compiler/parser/resolve_include.rs
+++ b/mimium-lang/src/compiler/parser/resolve_include.rs
@@ -1,20 +1,24 @@
 use super::{parse, Span};
+use crate::compiler::mirgen::convert_pronoun::convert_pronoun;
 use crate::interner::ExprNodeId;
 use crate::utils::error::{ReportableError, ReportableErrorDyn};
 use crate::utils::fileloader;
+
+fn make_vec_error<E: std::error::Error>(e: E, span: Span) -> Vec<Box<dyn ReportableError>> {
+    vec![Box::new(ReportableErrorDyn {
+        message: e.to_string(),
+        span: span.clone(),
+    }) as Box<dyn ReportableError>]
+}
 
 pub(super) fn resolve_include(
     mmm_filepath: &str,
     target_path: &str,
     span: Span,
 ) -> Result<ExprNodeId, Vec<Box<dyn ReportableError>>> {
-    let make_err = |e: fileloader::Error| {
-        vec![Box::new(ReportableErrorDyn {
-            message: e.to_string(),
-            span: span.clone(),
-        }) as Box<dyn ReportableError>]
-    };
-    let abspath = fileloader::get_canonical_path(mmm_filepath, target_path).map_err(make_err)?;
-    let content = fileloader::load(abspath.to_str().unwrap()).map_err(make_err)?;
+    let abspath = fileloader::get_canonical_path(mmm_filepath, target_path)
+        .map_err(|e| make_vec_error(e, span.clone()))?;
+    let content =
+        fileloader::load(abspath.to_str().unwrap()).map_err(|e| make_vec_error(e, span.clone()))?;
     parse(&content, Some(abspath))
 }

--- a/mimium-lang/src/compiler/parser/resolve_include.rs
+++ b/mimium-lang/src/compiler/parser/resolve_include.rs
@@ -1,0 +1,7 @@
+use crate::interner::ExprNodeId;
+
+pub struct Error{}
+
+pub fn resolve_include(file_path:&str)->Result<ExprNodeId,Error>{
+    todo!()
+}

--- a/mimium-lang/src/compiler/parser/statement.rs
+++ b/mimium-lang/src/compiler/parser/statement.rs
@@ -1,6 +1,6 @@
 use crate::{
     ast::Expr,
-    interner::{ExprNodeId, Symbol},
+    interner::ExprNodeId,
     pattern::{TypedId, TypedPattern},
 };
 
@@ -30,16 +30,14 @@ pub(super) fn into_then_expr(stmts: &[(Statement, Span)]) -> Option<ExprNodeId> 
     let e_pre = stmts.iter().rev().fold(None, |then, (stmt, span)| {
         let s = get_span(span.clone(), then);
         match (then, stmt) {
-            (_, Statement::Let(pat, body)) => {
-                Some(Expr::Let(pat.clone(), *body, then).into_id(s))
-            }
+            (_, Statement::Let(pat, body)) => Some(Expr::Let(pat.clone(), *body, then).into_id(s)),
 
             (_, Statement::LetRec(id, body)) => {
                 Some(Expr::LetRec(id.clone(), *body, then).into_id(s))
             }
-            (_, Statement::Assign(name, body)) => Some(
-                Expr::Then(Expr::Assign(*name, *body).into_id(span.clone()), then).into_id(s),
-            ),
+            (_, Statement::Assign(name, body)) => {
+                Some(Expr::Then(Expr::Assign(*name, *body).into_id(span.clone()), then).into_id(s))
+            }
             (_, Statement::MacroExpand(fname, body)) => {
                 //todo!
                 Some(Expr::LetRec(fname.clone(), *body, then).into_id(s))

--- a/mimium-lang/src/compiler/parser/statement.rs
+++ b/mimium-lang/src/compiler/parser/statement.rs
@@ -17,8 +17,30 @@ pub(super) enum Statement {
     Single(ExprNodeId),
 }
 
-// A helper function to convert vector of statements to nested expression
+pub fn stmt_from_expr_top(expr:ExprNodeId)->Vec<Statement>{
+    let mut res=vec![];
+    stmt_from_expr(expr,&mut res);
+    res
+}
+ fn stmt_from_expr(expr: ExprNodeId, target: &mut Vec<Statement>) {
+    match expr.to_expr() {
+        Expr::Let(pat, e, then_opt) => {
+            target.push(Statement::Let(pat, e));
+            if let Some(then) = then_opt {
+                stmt_from_expr(then, target);
+            }
+        }
+        Expr::LetRec(id, e, then_opt) => {
+            target.push(Statement::LetRec(id, e));
+            if let Some(then) = then_opt {
+                stmt_from_expr(then, target);
+            }
+        }
+        _ => target.push(Statement::Single(expr)),
+    }
+}
 
+// A helper function to convert vector of statements to nested expression
 pub(super) fn into_then_expr(stmts: &[(Statement, Span)]) -> Option<ExprNodeId> {
     let get_span = |spana: Span, spanb: Option<ExprNodeId>| match spanb {
         Some(b) => {

--- a/mimium-lang/src/compiler/parser/test.rs
+++ b/mimium-lang/src/compiler/parser/test.rs
@@ -7,7 +7,7 @@ use std::path::PathBuf;
 macro_rules! test_string {
     ($src:literal, $ans:expr) => {
         let srcstr = $src.to_string();
-        match parse(&srcstr) {
+        match parse(&srcstr, None) {
             Ok(ast) => {
                 assert!(
                     ast.to_expr() == $ans.to_expr(),
@@ -266,13 +266,16 @@ fn global_fnmultiple() {
             .into_id_with_span(0..28),
         },
         Expr::Lambda(
-            vec![TypedId {
-                id: "input".to_symbol(),
-                ty: Type::Unknown.into_id_with_span(8..13),
-            },TypedId {
-                id: "gue".to_symbol(),
-                ty: Type::Unknown.into_id_with_span(14..17),
-            }],
+            vec![
+                TypedId {
+                    id: "input".to_symbol(),
+                    ty: Type::Unknown.into_id_with_span(8..13),
+                },
+                TypedId {
+                    id: "gue".to_symbol(),
+                    ty: Type::Unknown.into_id_with_span(14..17),
+                },
+            ],
             None,
             Expr::Var("input".to_symbol()).into_id(21..26),
         )
@@ -374,8 +377,12 @@ fn test_stmt_without_return() {
     let ans = Expr::LetRec(
         TypedId {
             id: "test".to_symbol(),
-            ty: Type::Function(vec![Type::Unknown.into_id_with_span(0..56)], Type::Unknown.into_id_with_span(0..56), None)
-                .into_id_with_span(0..56),
+            ty: Type::Function(
+                vec![Type::Unknown.into_id_with_span(0..56)],
+                Type::Unknown.into_id_with_span(0..56),
+                None,
+            )
+            .into_id_with_span(0..56),
         },
         Expr::Lambda(
             vec![TypedId {
@@ -428,7 +435,7 @@ fn test_stmt_without_return() {
 #[should_panic]
 fn test_fail() {
     let src = "let 100 == hoge\n fuga";
-    match parse(&src.to_string()) {
+    match parse(&src.to_string(),None) {
         Err(errs) => {
             panic!("{}", utils::error::dump_to_string(&errs))
         }

--- a/mimium-lang/src/compiler/parser/token.rs
+++ b/mimium-lang/src/compiler/parser/token.rs
@@ -85,6 +85,8 @@ pub enum Token {
     Type,
     Alias,
 
+    Include,
+
     LineBreak,
 
     Comment(Comment),
@@ -182,6 +184,7 @@ impl fmt::Display for Token {
             Token::Return => write!(f, "return"),
             Token::Type => write!(f, "type"),
             Token::Alias => write!(f, "newtype"),
+            Token::Include => write!(f, "include"),
             Token::LineBreak => write!(f, "linebreak"),
             Token::Comment(_) => write!(f, "comment"),
             Token::EndOfInput => write!(f, "endofinput"),

--- a/mimium-lang/src/repl.rs
+++ b/mimium-lang/src/repl.rs
@@ -82,7 +82,7 @@ fn repl(data: &mut ReplAppData) -> ! {
                             Err(e) => error::report(&src, PathBuf::new(), &e),
                         }
                     }
-                    ReplMode::ShowAST => match compiler::emit_ast(&src) {
+                    ReplMode::ShowAST => match compiler::emit_ast(&src, None) {
                         Ok(ast) => {
                             println!("{}", ast.pretty_print());
                         }

--- a/mimium-lang/src/utils/error.rs
+++ b/mimium-lang/src/utils/error.rs
@@ -14,6 +14,23 @@ pub trait ReportableError: std::error::Error {
     }
 }
 
+#[derive(Debug)]
+pub struct ReportableErrorDyn {
+    pub message: String,
+    pub span: std::ops::Range<usize>,
+}
+impl std::fmt::Display for ReportableErrorDyn {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+impl std::error::Error for ReportableErrorDyn {}
+impl ReportableError for ReportableErrorDyn {
+    fn get_span(&self) -> std::ops::Range<usize> {
+        self.span.clone()
+    }
+}
+
 pub fn report<T>(src: &String, srcpath: T, errs: &Vec<Box<dyn ReportableError>>)
 where
     T: AsRef<path::Path>,

--- a/mimium-symphonia/src/filemanager.rs
+++ b/mimium-symphonia/src/filemanager.rs
@@ -1,4 +1,5 @@
-//copied from otopoiesis
+/// copied from otopoiesis code.
+/// TODO: move this to mimium-lang/utils/fileloader.
 use symphonia::core::io::MediaSource;
 
 pub trait FileManager {

--- a/mimium-test/src/lib.rs
+++ b/mimium-test/src/lib.rs
@@ -137,9 +137,14 @@ fn main() {
 }
 "#,
     );
-    let file: PathBuf = [crate_root.as_str(), "tests/mmm", path].iter().collect();
-    println!("{}", file.to_str().unwrap());
-    let (src, _path) = fileloader::load(file.to_string_lossy().to_string()).unwrap();
+    let file = [crate_root.as_str(), "tests/mmm", path]
+        .iter()
+        .collect::<PathBuf>()
+        .canonicalize()
+        .unwrap();
+    let file_str = file.to_str().unwrap();
+    println!("{}", file_str);
+    let src = fileloader::load(file_str).unwrap();
     (file, src)
 }
 

--- a/mimium-test/tests/intergration_test.rs
+++ b/mimium-test/tests/intergration_test.rs
@@ -301,3 +301,10 @@ fn fb_mem3_state_size() {
         [("counter", 1), ("mem_by_hand", 4), ("dsp", 5)],
     );
 }
+
+#[test]
+fn include_file() {
+    let res = run_file_test_mono("test_include.mmm", 10).unwrap();
+    let ans = vec![0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0];
+    assert_eq!(res, ans);
+}

--- a/mimium-test/tests/mmm/test_include.mmm
+++ b/mimium-test/tests/mmm/test_include.mmm
@@ -1,0 +1,4 @@
+include("test_include_target.mmm")
+fn dsp(){
+    hoge()
+}

--- a/mimium-test/tests/mmm/test_include_target.mmm
+++ b/mimium-test/tests/mmm/test_include_target.mmm
@@ -1,0 +1,3 @@
+fn hoge()->float{
+    self+1.0
+}


### PR DESCRIPTION
This PR implements basic preprocess feature `include("relative/filepath.mmm")`.

Currently, replacement is done in the parser stage. No namespace collisions are considered.

Also, span for included file are not handled correctly for now.(Error messages for included files will be corrupted...)


- write test cases for various types of path(how to test absolute path?)
- prevent including same file more than once