### PR TITLE
Fix bug in mirgen for delay

### DIFF
--- a/mimium-lang/src/compiler/mirgen.rs
+++ b/mimium-lang/src/compiler/mirgen.rs
@@ -85,6 +85,8 @@ impl Context {
         };
         match max.to_expr() {
             Expr::Literal(Literal::Float(max)) => {
+                //need to evaluate args first before calculate state offset because the argument for time contains stateful function call.
+                let args = self.eval_args(&[*src, *time])?;
                 let max_time = max.parse::<f64>().unwrap();
                 let shift_size = max_time as u64 + DELAY_ADDITIONAL_OFFSET;
                 self.get_current_fn().state_sizes.push(StateSize {
@@ -98,7 +100,6 @@ impl Context {
                         .0
                         .push((Arc::new(Value::None), Instruction::PushStateOffset(coffset)));
                 }
-                let args = self.eval_args(&[*src, *time])?;
                 let (args, _types): (Vec<VPtr>, Vec<TypeNodeId>) = args.into_iter().unzip();
                 Ok(Some(self.push_inst(Instruction::Delay(
                     max_time as u64,

--- a/mimium-lang/src/compiler/mirgen.rs
+++ b/mimium-lang/src/compiler/mirgen.rs
@@ -75,7 +75,7 @@ impl Context {
     }
     fn make_delay(&mut self, f: &VPtr, args: &[ExprNodeId]) -> Result<Option<VPtr>, CompileError> {
         let rt = match f.as_ref() {
-            Value::ExtFunction(name, rt) if *name != "delay".to_symbol() => rt,
+            Value::ExtFunction(name, ft) if *name == "delay".to_symbol() => ft,
             _ => return Ok(None),
         };
 
@@ -83,9 +83,8 @@ impl Context {
             [max, src, time] => (max, src, time),
             _ => return Ok(None),
         };
-
-        match (rt.to_type(), max.to_expr()) {
-            (Type::Primitive(PType::Numeric), Expr::Literal(Literal::Float(max))) => {
+        match max.to_expr() {
+            Expr::Literal(Literal::Float(max)) => {
                 let max_time = max.parse::<f64>().unwrap();
                 let shift_size = max_time as u64 + DELAY_ADDITIONAL_OFFSET;
                 self.get_current_fn().state_sizes.push(StateSize {

--- a/mimium-lang/src/runtime/vm/ringbuffer.rs
+++ b/mimium-lang/src/runtime/vm/ringbuffer.rs
@@ -4,22 +4,22 @@ use super::RawVal;
 
 #[repr(C)]
 pub(super) struct Ringbuffer<'a> {
-    read_idx: &'a mut [u64],
-    write_idx: &'a mut [u64],
+    read_idx: &'a mut u64,
+    write_idx: &'a mut u64,
     data: &'a mut [u64],
 }
 
 impl<'a> Ringbuffer<'a> {
     pub fn new(head: *mut u64, size_in_samples: u64) -> Self {
         let (read_idx, write_idx, data) = unsafe {
-            let read_idx = slice_from_raw_parts_mut(head, 1 as usize);
+            let read_idx =  head.as_mut().unwrap_unchecked();
             let write_ptr = head.offset(1);
-            let write_idx = slice_from_raw_parts_mut(write_ptr, 1 as usize);
+            let write_idx = write_ptr.as_mut().unwrap_unchecked();
             let data_head = head.offset(2);
             let data = slice_from_raw_parts_mut(data_head, size_in_samples as usize);
             (
-                read_idx.as_mut().unwrap(),
-                write_idx.as_mut().unwrap(),
+                read_idx,
+                write_idx,
                 data.as_mut().unwrap(),
             )
         };
@@ -34,12 +34,12 @@ impl<'a> Ringbuffer<'a> {
         let len = self.data.len() as u64;
         let res = unsafe {
             let time = std::mem::transmute::<u64, f64>(time_raw) as u64;
-            let read_idx = *self.read_idx.get_unchecked(0);
-            *self.write_idx.get_unchecked_mut(0) = (read_idx + time) % len;
-            let write_idx = *self.write_idx.get_unchecked(0);
+            let read_idx = *self.read_idx;
+            *self.write_idx = (read_idx + time) % len;
+            let write_idx = *self.write_idx;
             let res = *self.data.get_unchecked(read_idx as usize);
             *self.data.get_unchecked_mut(write_idx as usize) = input;
-            *self.read_idx.get_unchecked_mut(0) = (read_idx + 1) % len;
+            *self.read_idx = (read_idx + 1) % len;
             res
         };
         res

--- a/mimium-test/tests/intergration_test.rs
+++ b/mimium-test/tests/intergration_test.rs
@@ -303,6 +303,19 @@ fn fb_mem3_state_size() {
 }
 
 #[test]
+fn delay() {
+    let res = run_file_test_mono("delay.mmm", 10).unwrap();
+    let ans = vec![0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 4.0];
+    assert_eq!(res, ans);
+}
+#[test]
+fn delay2() {
+    let res = run_file_test_mono("delay2.mmm", 10).unwrap();
+    let ans = vec![0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 4.0];
+    assert_eq!(res, ans);
+}
+
+#[test]
 fn include_file() {
     let res = run_file_test_mono("test_include.mmm", 10).unwrap();
     let ans = vec![0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0];

--- a/mimium-test/tests/mmm/delay.mmm
+++ b/mimium-test/tests/mmm/delay.mmm
@@ -1,7 +1,8 @@
-fn fbdelay(input,time,fb){
-    delay(300.0,input+self*fb,time)
+fn counter(){
+    self+1.0
 }
 
 fn dsp(){
-    fbdelay(1.0,100.0,0.8)+fbdelay(2.0,200.0,0.7)
+    let c = counter()
+    delay(10.0,c,5.0)
 }

--- a/mimium-test/tests/mmm/delay2.mmm
+++ b/mimium-test/tests/mmm/delay2.mmm
@@ -1,0 +1,6 @@
+fn counter(){
+    self+1.0
+}
+fn dsp(){
+    delay(10.0,counter(),5.0)
+}


### PR DESCRIPTION
This PR fixes the bug in the MIR generator for delay.

I don't know why but the condition of the function name was inverted. 