### PR TITLE
Basic wasm32 debug configuration with WASI backend.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -39,8 +39,41 @@
                     "kind": "bin"
                 }
             },
-            "args": ["mimium-cli/examples/sinewave.mmm"],
+            "args": [
+                "mimium-cli/examples/sinewave.mmm"
+            ],
             "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug wasi executable",
+            "cargo": {
+                "args": [
+                    "build",
+                    "--bin=mimium-cli",
+                    "--package=mimium-cli",
+                    "--target=wasm32-wasip2"
+                ],
+                "filter": {
+                    "name": "mimium-cli",
+                    "kind": "bin"
+                }
+            },
+            "program": "~/.wasmtime/bin/wasmtime",
+            "args": [
+                "run",
+                "--dir",
+                ".",
+                "-D",
+                "debug-info",
+                "target/wasm32-wasip2/debug/mimium-cli.wasm",
+                "mimium-cli/examples/sinewave.mmm"
+            ],
+            "cwd": "${workspaceFolder}",
+            "env": {
+                "_NO_DEBUG_HEAP": "1"
+            }
         },
         {
             "type": "lldb",
@@ -57,14 +90,14 @@
                     "kind": "bin"
                 }
             },
-            "args": ["tests/mmm/mir_counter.mmm"],
+            "args": [
+                "tests/mmm/mir_counter.mmm"
+            ],
             "cwd": "${workspaceFolder}"
         },
-
         {
             "type": "lldb",
             "request": "launch",
-            
             "name": "Debug unit tests in executable 'mimium-rs'",
             "cargo": {
                 "args": [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,7 +209,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eebd66744a15ded14960ab4ccdbfb51ad3b81f51f3f04a80adac98c985396c9"
 dependencies = [
  "hashbrown",
- "stacker",
 ]
 
 [[package]]
@@ -757,15 +756,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "psm"
-version = "0.1.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5787f7cda34e3033a72192c018bc5883100330f362ef279a8cbccfce8bb4e874"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -860,19 +850,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbff4acf519f630b3a3ddcfaea6c06b42174d9a44bc70c620e9ed1649d58b82a"
 dependencies = [
  "version_check",
-]
-
-[[package]]
-name = "stacker"
-version = "0.1.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c886bd4480155fd3ef527d45e9ac8dd7118a898a46530b7b94c3e21866259fce"
-dependencies = [
- "cc",
- "cfg-if",
- "libc",
- "psm",
- "winapi",
 ]
 
 [[package]]
@@ -1184,22 +1161,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
 name = "winapi-util"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1207,12 +1168,6 @@ checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
 dependencies = [
  "windows-sys 0.52.0",
 ]
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"

--- a/mimium-lang/Cargo.toml
+++ b/mimium-lang/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 
 [dependencies]
 
-chumsky = "0.9"
+chumsky = { version = "0.9", default-features = false, features = ["std"] }
 ariadne = "0.4"
 log = "0.4.22"
 string-interner = "0.17.0"


### PR DESCRIPTION
This is the basic setup for debugging wasm32 target with wasmtime.

You need to add wasm32-wasip2 backend beforehand

```sh
rustup target add wasm32-wasip2
```

and need to install wasmtime in `~/.wasmtime/bin/wasmtime` .

```sh
curl https://wasmtime.dev/install.sh -sSf | bash
```

And you can launch wasm version cli through "Debug wasi executable" from debug tab.

*Importantly, you can't play any sound because WASI does not proivide audio driver*.


However, this setup still useful for debugging wasm binary for web platform for the future implementation.
