### PR TITLE
Prevent from predefined functions overwritten by users

### DIFF
--- a/mimium-lang/src/compiler/intrinsics.rs
+++ b/mimium-lang/src/compiler/intrinsics.rs
@@ -2,7 +2,6 @@
 pub(crate) const NEG: &'static str = "neg";
 pub(crate) const TOFLOAT: &'static str = "tofloat";
 
-
 // binary
 pub(crate) const ADD: &'static str = "add";
 pub(crate) const SUB: &'static str = "sub";
@@ -22,9 +21,9 @@ pub(crate) const OR: &'static str = "or";
 // arithmetics
 pub(crate) const SIN: &'static str = "sin";
 pub(crate) const COS: &'static str = "cos";
-// pub(crate) const TAN: &'static str = "tan";
-// pub(crate) const ATAN: &'static str = "atan";
-// pub(crate) const ATAN2: &'static str = "atan2";
+pub(crate) const TAN: &'static str = "tan";
+pub(crate) const ATAN: &'static str = "atan";
+pub(crate) const ATAN2: &'static str = "atan2";
 pub(crate) const SQRT: &'static str = "sqrt";
 pub(crate) const ABS: &'static str = "abs";
 pub(crate) const LOG: &'static str = "log";
@@ -32,3 +31,8 @@ pub(crate) const LOG: &'static str = "log";
 // other operations
 pub(crate) const DELAY: &'static str = "delay";
 pub(crate) const MEM: &'static str = "mem";
+
+pub(crate) const BUILTIN_SYMS: [&str; 26] = [
+    NEG,TOFLOAT,ADD, SUB, MULT, DIV, EQ, NE, LE, LT, GE, GT, MODULO, EXP, AND, OR, SIN, COS, TAN, ATAN, ATAN2,
+    SQRT, ABS, LOG, DELAY, MEM,
+];

--- a/mimium-lang/src/compiler/intrinsics.rs
+++ b/mimium-lang/src/compiler/intrinsics.rs
@@ -1,3 +1,7 @@
+use std::cell::LazyCell;
+
+use crate::interner::{Symbol, ToSymbol};
+
 // unary
 pub(crate) const NEG: &'static str = "neg";
 pub(crate) const TOFLOAT: &'static str = "tofloat";
@@ -31,8 +35,15 @@ pub(crate) const LOG: &'static str = "log";
 // other operations
 pub(crate) const DELAY: &'static str = "delay";
 pub(crate) const MEM: &'static str = "mem";
-
-pub(crate) const BUILTIN_SYMS: [&str; 26] = [
-    NEG,TOFLOAT,ADD, SUB, MULT, DIV, EQ, NE, LE, LT, GE, GT, MODULO, EXP, AND, OR, SIN, COS, TAN, ATAN, ATAN2,
-    SQRT, ABS, LOG, DELAY, MEM,
+const BUILTIN_SYMS_UNSORTED: [&str; 26] = [
+    NEG, TOFLOAT, ADD, SUB, MULT, DIV, EQ, NE, LE, LT, GE, GT, MODULO, EXP, AND, OR, SIN, COS, TAN,
+    ATAN, ATAN2, SQRT, ABS, LOG, DELAY, MEM,
 ];
+thread_local!(pub (crate) static BUILTIN_SYMS: LazyCell<Vec<Symbol>> = LazyCell::new(|| {
+    let mut v = BUILTIN_SYMS_UNSORTED
+        .iter()
+        .map(|s| s.to_symbol())
+        .collect::<Vec<_>>();
+    v.sort();
+    v
+}));

--- a/mimium-lang/src/compiler/parser.rs
+++ b/mimium-lang/src/compiler/parser.rs
@@ -311,7 +311,7 @@ fn validate_reserved_pat(id: &TypedPattern, span: Span) -> Result<(), Simple<Tok
 }
 
 fn validate_reserved_ident(id: Symbol, span: Span) -> Result<(), Simple<Token>> {
-    if intrinsics::BUILTIN_SYMS.contains(&id.as_str()) {
+    if intrinsics::BUILTIN_SYMS.with(|syms| syms.binary_search(&id).is_ok()) {
         Err(Simple::custom(
             span,
             "Builtin functions cannot be re-defined.",

--- a/mimium-lang/src/compiler/parser.rs
+++ b/mimium-lang/src/compiler/parser.rs
@@ -17,6 +17,8 @@ mod resolve_include;
 mod statement;
 use statement::{into_then_expr, stmt_from_expr_top, Statement};
 
+use super::intrinsics;
+
 #[cfg(test)]
 mod test;
 
@@ -301,17 +303,45 @@ fn expr_parser(expr_group: ExprParser<'_>) -> ExprParser<'_> {
 //         .labelled("assign");
 //     let_stmt.or(assign)
 // }
+fn validate_reserved_pat(id: &TypedPattern, span: Span) -> Result<(), Simple<Token>> {
+    match &id.pat {
+        Pattern::Single(symbol) => validate_reserved_ident(*symbol, span),
+        _ => Ok(()),
+    }
+}
+
+fn validate_reserved_ident(id: Symbol, span: Span) -> Result<(), Simple<Token>> {
+    if intrinsics::BUILTIN_SYMS.contains(&id.as_str()) {
+        Err(Simple::custom(
+            span,
+            "Builtin functions cannot be re-defined.",
+        ))
+    } else {
+        Ok(())
+    }
+}
+
 fn statement_parser(
     expr: ExprParser<'_>,
 ) -> impl Parser<Token, (Statement, Span), Error = Simple<Token>> + Clone + '_ {
     let let_ = just(Token::Let)
-        .ignore_then(pattern_parser().clone())
+        .ignore_then(pattern_parser().clone().validate(|pat, span, emit| {
+            if let Err(e) = validate_reserved_pat(&pat, span.clone()) {
+                emit(e);
+            }
+            pat
+        }))
         .then_ignore(just(Token::Assign))
         .then(expr.clone())
         .map_with_span(|(ident, body), span| (Statement::Let(ident, body), span))
         .labelled("let");
     let letrec = just(Token::LetRec)
-        .ignore_then(lvar_parser_typed())
+        .ignore_then(lvar_parser_typed().validate(|ident, span, emit| {
+            if let Err(e) = validate_reserved_ident(ident.id, span.clone()) {
+                emit(e);
+            }
+            ident
+        }))
         .then_ignore(just(Token::Assign))
         .then(expr.clone())
         .map_with_span(|(ident, body), span| (Statement::LetRec(ident, body), span))
@@ -410,7 +440,12 @@ fn func_parser(
         .labelled("fnparams");
 
     let function_s = just(Token::Function)
-        .ignore_then(lvar.clone())
+        .ignore_then(lvar.clone().validate(|ident, span, emit| {
+            if let Err(e) = validate_reserved_ident(ident.id, span) {
+                emit(e);
+            }
+            ident
+        }))
         .then(fnparams.clone())
         .then(just(Token::Arrow).ignore_then(type_parser()).or_not())
         .then(block_parser(exprgroup.clone()).map(|e| match e.to_expr() {
@@ -521,8 +556,8 @@ pub fn parse(
         let (ast, parse_errs) = parser(current_file)
             .parse_recovery(chumsky::Stream::from_iter(len..len + 1, t.into_iter()));
         match ast {
-            Some(ast) => Ok(ast),
-            None => {
+            Some(ast) if parse_errs.is_empty() => Ok(ast),
+            _ => {
                 parse_errs
                     .iter()
                     .for_each(|e| errs.push(Box::new(error::ParseError::<Token>(e.clone()))));

--- a/mimium-lang/src/compiler/parser/test.rs
+++ b/mimium-lang/src/compiler/parser/test.rs
@@ -441,3 +441,18 @@ fn test_fail() {
         _ => {}
     };
 }
+
+#[test]
+fn test_err_builtin_redefine() {
+    let src = r"fn div(){
+    0.0
+}
+100.0";
+    let res = &parse(&src.to_string(), None).expect_err("should be error");
+    assert_eq!(res.len(), 1);
+
+    let err_ans: Box<dyn ReportableError> = Box::new(error::ParseError::<Token>(
+        Simple::custom(3..6, "Builtin functions cannot be re-defined.").with_label("function decl"),
+    ));
+    assert_eq!(res[0].to_string(), err_ans.to_string())
+}

--- a/mimium-lang/src/interner.rs
+++ b/mimium-lang/src/interner.rs
@@ -82,7 +82,7 @@ where
     SESSION_GLOBALS.with_borrow_mut(f)
 }
 
-#[derive(Default, Copy, Clone, PartialEq, Debug, Hash, Eq)]
+#[derive(Default, Copy, Clone, PartialEq, Debug, Hash, Eq, PartialOrd, Ord)]
 pub struct Symbol(pub usize); //Symbol Trait is implemented on usize
 
 pub trait ToSymbol {


### PR DESCRIPTION
This PR addresses #57.

I simply added a validation function in the parser so that the predefined functions are not redefined by the user.

Still user can re-define variable with `let` (=shadowing). Shadowing helps with duplicate symbol conflicts, even if the same files are included multiple times with the current dirty implementation of `include'.