### PR TITLE
Midi Input Plugin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,6 +116,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "atomic_float"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "628d228f918ac3b82fe590352cc719d30664a0c13ca3a60266fe02c7132d480a"
+
+[[package]]
 name = "autocfg"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -656,10 +662,12 @@ dependencies = [
 name = "mimium-midi"
 version = "2.0.0-alpha-1"
 dependencies = [
+ "atomic_float",
  "log",
  "midir",
  "mimium-lang",
  "mimium-test",
+ "wmidi",
 ]
 
 [[package]]
@@ -1573,6 +1581,12 @@ checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "wmidi"
+version = "4.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e55f35b40ad0178422d06e9ba845041baf2faf04627b91fde928d0f6a21c712"
 
 [[package]]
 name = "yansi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,6 +154,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
+name = "block"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
+
+[[package]]
 name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -300,6 +306,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -326,6 +342,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "coremidi"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "964eb3e10ea8b0d29c797086aab3ca730f75e06dced0cb980642fd274a5cca30"
+dependencies = [
+ "block",
+ "core-foundation",
+ "core-foundation-sys",
+ "coremidi-sys",
+]
+
+[[package]]
+name = "coremidi-sys"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709d142e542467e028d5dc5f0374392339ab7dead0c48c129504de2ccd667e1b"
+dependencies = [
+ "core-foundation-sys",
+]
+
+[[package]]
 name = "cpal"
 version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -345,7 +382,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "windows",
+ "windows 0.54.0",
 ]
 
 [[package]]
@@ -532,6 +569,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "lock_api"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -551,6 +598,23 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "midir"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe36f39751eb1f449490d4a236e8642c8efee1a87fa81785b063289b689dc84e"
+dependencies = [
+ "alsa",
+ "bitflags 1.3.2",
+ "coremidi",
+ "js-sys",
+ "libc",
+ "parking_lot",
+ "wasm-bindgen",
+ "web-sys",
+ "windows 0.56.0",
+]
 
 [[package]]
 name = "mimium-audiodriver"
@@ -586,6 +650,15 @@ dependencies = [
  "log",
  "slotmap",
  "string-interner",
+]
+
+[[package]]
+name = "mimium-midi"
+version = "2.0.0-alpha-1"
+dependencies = [
+ "midir",
+ "mimium-lang",
+ "mimium-test",
 ]
 
 [[package]]
@@ -732,6 +805,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
+name = "parking_lot"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets 0.52.5",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -762,6 +858,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
+dependencies = [
+ "bitflags 2.6.0",
 ]
 
 [[package]]
@@ -818,6 +923,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
 name = "serde"
 version = "1.0.208"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -851,6 +962,12 @@ checksum = "dbff4acf519f630b3a3ddcfaea6c06b42174d9a44bc70c620e9ed1649d58b82a"
 dependencies = [
  "version_check",
 ]
+
+[[package]]
+name = "smallvec"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "string-interner"
@@ -1175,7 +1292,17 @@ version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9252e5725dbed82865af151df558e754e4a3c2c30818359eb17465f1346a1b49"
 dependencies = [
- "windows-core",
+ "windows-core 0.54.0",
+ "windows-targets 0.52.5",
+]
+
+[[package]]
+name = "windows"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1de69df01bdf1ead2f4ac895dc77c9351aefff65b2f3db429a343f9cbf05e132"
+dependencies = [
+ "windows-core 0.56.0",
  "windows-targets 0.52.5",
 ]
 
@@ -1187,6 +1314,40 @@ checksum = "12661b9c89351d684a50a8a643ce5f608e20243b9fb84687800163429f161d65"
 dependencies = [
  "windows-result",
  "windows-targets 0.52.5",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4698e52ed2d08f8658ab0c39512a7c00ee5fe2688c65f8c0a4f06750d729f2a6"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-result",
+ "windows-targets 0.52.5",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6fc35f58ecd95a9b71c4f2329b911016e6bec66b3f2e6a4aad86bd2e99e2f9b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08990546bf4edef8f431fa6326e032865f27138718c587dc21bc0265bbcb57cc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -656,6 +656,7 @@ dependencies = [
 name = "mimium-midi"
 version = "2.0.0-alpha-1"
 dependencies = [
+ "log",
  "midir",
  "mimium-lang",
  "mimium-test",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -642,6 +642,7 @@ dependencies = [
  "log",
  "mimium-audiodriver",
  "mimium-lang",
+ "mimium-midi",
  "mimium-scheduler",
  "mimium-symphonia",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "mimium-test",
     "mimium-scheduler",
     "mimium-symphonia",
+    "mimium-midi",
 ]
 
 resolver = "2"

--- a/mimium-audiodriver/src/backends/cpal.rs
+++ b/mimium-audiodriver/src/backends/cpal.rs
@@ -239,7 +239,7 @@ impl Driver for NativeDriver {
         let odevice = host.default_output_device();
         let out_stream = if let Some(odevice) = odevice {
             let mut processor = NativeAudioData::new(ctx, cons, self.count.clone());
-            processor.vmdata.vm.execute_main();
+            processor.vmdata.run_main();
             let mut oconfig = Self::init_oconfig(&odevice, sample_rate);
             oconfig.buffer_size = cpal::BufferSize::Fixed((self.buffer_size / BUFFER_RATIO) as u32);
             log::info!(

--- a/mimium-audiodriver/src/driver.rs
+++ b/mimium-audiodriver/src/driver.rs
@@ -96,7 +96,13 @@ impl RuntimeData {
             let p = unsafe { plug.0.get().as_mut().unwrap_unchecked() };
             let _ = p.on_init(&mut self.vm);
         });
-        self.vm.execute_main()
+        let res = self.vm.execute_main();
+        self.sys_plugins.iter().for_each(|plug: &DynSystemPlugin| {
+            //todo: encapsulate unsafety within SystemPlugin functionality
+            let p = unsafe { plug.0.get().as_mut().unwrap_unchecked() };
+            let _ = p.after_main(&mut self.vm);
+        });
+        res
     }
     pub fn get_dsp_fn(&self) -> &FuncProto {
         &self.vm.prog.global_fn_table[self.dsp_i].1

--- a/mimium-cli/Cargo.toml
+++ b/mimium-cli/Cargo.toml
@@ -16,6 +16,7 @@ log = "0.4.22"
 
 mimium-lang = { path = "../mimium-lang" }
 mimium-audiodriver = { path = "../mimium-audiodriver" }
+mimium-midi = { path = "../mimium-midi" }
 mimium-symphonia = { path = "../mimium-symphonia" }
 mimium-scheduler = { path = "../mimium-scheduler" }
 colog = "1.3.0"

--- a/mimium-cli/examples/midiin.mmm
+++ b/mimium-cli/examples/midiin.mmm
@@ -1,6 +1,6 @@
-let _ = set_midi_port("from Max 2")
 let pi = 3.14159265359
 let sr = 44100.0
+let _ = set_midi_port("from Max 2")
 fn phasor(freq){
   (self + freq/sr)%1.0
 }

--- a/mimium-cli/examples/midiin.mmm
+++ b/mimium-cli/examples/midiin.mmm
@@ -7,7 +7,7 @@ fn osc(freq){
   sin(phasor(freq)*pi*2.0)
 }
 fn midi_to_hz(note){
-    440.0*  (2.0 ^(note-69.0)/12.0)
+    440.0*  (2.0 ^((note-69.0)/12.0))
 }
 
 let boundval = bind_midi_note_mono(0.0);
@@ -16,5 +16,6 @@ fn dsp(){
     let (note,vel) = boundval();
 
     let sig = note |> midi_to_hz |> osc 
-    sig * vel /127.0
+    let r = sig * (vel /127.0);
+    (r,r)
 }

--- a/mimium-cli/examples/midiin.mmm
+++ b/mimium-cli/examples/midiin.mmm
@@ -1,0 +1,20 @@
+let pi = 3.14159265359
+let sr = 44100.0
+fn phasor(freq){
+  (self + freq/sr)%1.0
+}
+fn osc(freq){
+  sin(phasor(freq)*pi*2.0)
+}
+fn midi_to_hz(note){
+    440.0*  (2.0 ^(note-69.0)/12.0)
+}
+
+let boundval = bind_midi_note_mono(0.0);
+
+fn dsp(){
+    let (note,vel) = boundval();
+
+    let sig = note |> midi_to_hz |> osc 
+    sig * vel /127.0
+}

--- a/mimium-cli/examples/midiin.mmm
+++ b/mimium-cli/examples/midiin.mmm
@@ -1,3 +1,4 @@
+let _ = set_midi_port("from Max 2")
 let pi = 3.14159265359
 let sr = 44100.0
 fn phasor(freq){
@@ -9,7 +10,6 @@ fn osc(freq){
 fn midi_to_hz(note){
     440.0*  (2.0 ^((note-69.0)/12.0))
 }
-
 let boundval = bind_midi_note_mono(0.0,69.0,127.0);
 
 fn dsp(){

--- a/mimium-cli/examples/midiin.mmm
+++ b/mimium-cli/examples/midiin.mmm
@@ -10,7 +10,7 @@ fn midi_to_hz(note){
     440.0*  (2.0 ^((note-69.0)/12.0))
 }
 
-let boundval = bind_midi_note_mono(0.0);
+let boundval = bind_midi_note_mono(0.0,69.0,127.0);
 
 fn dsp(){
     let (note,vel) = boundval();

--- a/mimium-cli/src/main.rs
+++ b/mimium-cli/src/main.rs
@@ -106,9 +106,7 @@ fn get_default_context(path: Option<Symbol>) -> ExecContext {
     let plugins: Vec<Box<dyn Plugin>> = vec![Box::new(SamplerPlugin)];
     let mut ctx = ExecContext::new(plugins.into_iter(), path);
     ctx.add_system_plugin(mimium_scheduler::get_default_scheduler_plugin());
-    let _ = mimium_midi::MidiPlugin::try_new().map(|p| {
-        ctx.add_system_plugin(p);
-    });
+    ctx.add_system_plugin(mimium_midi::MidiPlugin::default());
     ctx
 }
 

--- a/mimium-cli/src/main.rs
+++ b/mimium-cli/src/main.rs
@@ -13,6 +13,7 @@ use mimium_lang::utils::miniprint::MiniPrint;
 use mimium_lang::utils::{error::report, fileloader};
 use mimium_lang::ExecContext;
 use mimium_lang::{compiler::mirgen::convert_pronoun, repl};
+use mimium_midi;
 use mimium_symphonia::{self, SamplerPlugin};
 #[derive(clap::Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -105,6 +106,9 @@ fn get_default_context(path: Option<Symbol>) -> ExecContext {
     let plugins: Vec<Box<dyn Plugin>> = vec![Box::new(SamplerPlugin)];
     let mut ctx = ExecContext::new(plugins.into_iter(), path);
     ctx.add_system_plugin(mimium_scheduler::get_default_scheduler_plugin());
+    let _ = mimium_midi::MidiPlugin::try_new().map(|p| {
+        ctx.add_system_plugin(p);
+    });
     ctx
 }
 

--- a/mimium-lang/lib/core.mmm
+++ b/mimium-lang/lib/core.mmm
@@ -9,7 +9,7 @@ fn switch(gate,a,b){
 }
 
 fn midi_to_hz(note){
-    440.0*pow(2.0, (note-69.0)/12.0)
+    440.0*(2.0^ ((note-69.0)/12.0) )
 }
 
 fn hz_to_midi(freq){

--- a/mimium-lang/lib/env.mmm
+++ b/mimium-lang/lib/env.mmm
@@ -1,3 +1,22 @@
-fn sig_dir(x){
-    if (x>self) 1.0 else if (x<self) -1.0 else 0.0
+fn sec2samp(sec){
+    sec*48000.0
+}
+fn countup(active){
+    let r  =(self+1.0);
+    if (active) r else 0.0
+}
+fn countupn(time,active){
+    let res = countup(active)
+    if(res<time) res else 0.0
+}
+fn hold(time,active){
+    countupn(time,active)>0.0
+}
+fn adsr(attack,decay,sustain,release,input){
+    atsig = min(1.0,(self + 1.0/sec2samp(attack)))
+    decsig = max(sustain,(self-1.0/sec2samp(decay)))
+    releasesig =max(0,(self-1.0/sec2samp(release)))
+    at_or_dec = hold(sec2samp(attack),input>0.0)*input
+    at_dec_sus_sig = if (at_or_dec) atsig else decsig
+    if (input>0.5) at_dec_sus_sig else releasesig
 }

--- a/mimium-lang/lib/env.mmm
+++ b/mimium-lang/lib/env.mmm
@@ -3,20 +3,24 @@ fn sec2samp(sec){
 }
 fn countup(active){
     let r  =(self+1.0);
-    if (active) r else 0.0
+    let rr = if (active) r else 0.0
+    rr
 }
 fn countupn(time,active){
     let res = countup(active)
-    if(res<time) res else 0.0
+    let r = if(res<time) res else 0.0
+    r
 }
 fn hold(time,active){
     countupn(time,active)>0.0
 }
 fn adsr(attack,decay,sustain,release,input){
-    atsig = min(1.0,(self + 1.0/sec2samp(attack)))
-    decsig = max(sustain,(self-1.0/sec2samp(decay)))
-    releasesig =max(0,(self-1.0/sec2samp(release)))
-    at_or_dec = hold(sec2samp(attack),input>0.0)*input
-    at_dec_sus_sig = if (at_or_dec) atsig else decsig
-    if (input>0.5) at_dec_sus_sig else releasesig
+    let s = self;
+    let atsig = min(1.0,(s + 1.0/sec2samp(attack)))
+    let decsig = max(sustain,(s-1.0/sec2samp(decay)))
+    let releasesig =max(0.0,(s-1.0/sec2samp(release)))
+    let at_or_dec = hold(sec2samp(attack),input>0.0)*input
+    let at_dec_sus_sig = if (at_or_dec) atsig else decsig
+    let res = if (input>0.5) at_dec_sus_sig else releasesig
+    res
 }

--- a/mimium-lang/src/compiler/bytecodegen.rs
+++ b/mimium-lang/src/compiler/bytecodegen.rs
@@ -332,9 +332,10 @@ impl ByteCodeGenerator {
             }
             mir::Instruction::String(s) => {
                 let pos = self.program.add_new_str(*s);
+                let cpos = funcproto.add_new_constant(pos as u64);
                 Some(VmInstruction::MoveConst(
                     self.get_destination(dst, 1),
-                    pos as ConstPos,
+                    cpos as ConstPos,
                 ))
             }
             mir::Instruction::Alloc(t) => {

--- a/mimium-lang/src/compiler/intrinsics.rs
+++ b/mimium-lang/src/compiler/intrinsics.rs
@@ -18,7 +18,7 @@ pub(crate) const LT: &'static str = "lt";
 pub(crate) const GE: &'static str = "ge";
 pub(crate) const GT: &'static str = "gt";
 pub(crate) const MODULO: &'static str = "modulo";
-pub(crate) const EXP: &'static str = "exp";
+pub(crate) const POW: &'static str = "pow";
 pub(crate) const AND: &'static str = "and";
 pub(crate) const OR: &'static str = "or";
 
@@ -36,7 +36,7 @@ pub(crate) const LOG: &'static str = "log";
 pub(crate) const DELAY: &'static str = "delay";
 pub(crate) const MEM: &'static str = "mem";
 const BUILTIN_SYMS_UNSORTED: [&str; 26] = [
-    NEG, TOFLOAT, ADD, SUB, MULT, DIV, EQ, NE, LE, LT, GE, GT, MODULO, EXP, AND, OR, SIN, COS, TAN,
+    NEG, TOFLOAT, ADD, SUB, MULT, DIV, EQ, NE, LE, LT, GE, GT, MODULO, POW, AND, OR, SIN, COS, TAN,
     ATAN, ATAN2, SQRT, ABS, LOG, DELAY, MEM,
 ];
 thread_local!(pub (crate) static BUILTIN_SYMS: LazyCell<Vec<Symbol>> = LazyCell::new(|| {

--- a/mimium-lang/src/compiler/intrinsics.rs
+++ b/mimium-lang/src/compiler/intrinsics.rs
@@ -31,13 +31,18 @@ pub(crate) const ATAN2: &'static str = "atan2";
 pub(crate) const SQRT: &'static str = "sqrt";
 pub(crate) const ABS: &'static str = "abs";
 pub(crate) const LOG: &'static str = "log";
+pub(crate) const MIN: &'static str = "min";
+pub(crate) const MAX: &'static str = "max";
+pub(crate) const CEIL: &'static str = "ceil";
+pub(crate) const FLOOR: &'static str = "floor";
+pub(crate) const ROUND: &'static str = "round";
 
 // other operations
 pub(crate) const DELAY: &'static str = "delay";
 pub(crate) const MEM: &'static str = "mem";
-const BUILTIN_SYMS_UNSORTED: [&str; 26] = [
+const BUILTIN_SYMS_UNSORTED: [&str; 31] = [
     NEG, TOFLOAT, ADD, SUB, MULT, DIV, EQ, NE, LE, LT, GE, GT, MODULO, POW, AND, OR, SIN, COS, TAN,
-    ATAN, ATAN2, SQRT, ABS, LOG, DELAY, MEM,
+    ATAN, ATAN2, SQRT, ABS, LOG, MIN, MAX, CEIL, FLOOR, ROUND, DELAY, MEM,
 ];
 thread_local!(pub (crate) static BUILTIN_SYMS: LazyCell<Vec<Symbol>> = LazyCell::new(|| {
     let mut v = BUILTIN_SYMS_UNSORTED

--- a/mimium-lang/src/compiler/mirgen.rs
+++ b/mimium-lang/src/compiler/mirgen.rs
@@ -655,6 +655,7 @@ impl Context {
                         self.fn_label.map_or("".to_string(), |s| s.to_string())
                     )
                 };
+                let insert_bb = self.get_ctxdata().current_bb;
                 let insert_pos = if self.program.functions.is_empty() {
                     0
                 } else {
@@ -671,7 +672,7 @@ impl Context {
                 ) {
                     (false, false, Some(then_e)) => {
                         let alloc_res = self.gen_new_register();
-                        let block = &mut self.get_current_basicblock().0;
+                        let block = &mut self.get_current_fn().body.get_mut(insert_bb).unwrap().0;
                         block.insert(insert_pos, (alloc_res.clone(), Instruction::Alloc(t)));
                         let _ =
                             self.push_inst(Instruction::Store(alloc_res.clone(), bodyv.clone(), t));

--- a/mimium-lang/src/compiler/mirgen.rs
+++ b/mimium-lang/src/compiler/mirgen.rs
@@ -126,7 +126,7 @@ impl Context {
             intrinsics::SUB => Some(Instruction::SubF(a0, a1)),
             intrinsics::MULT => Some(Instruction::MulF(a0, a1)),
             intrinsics::DIV => Some(Instruction::DivF(a0, a1)),
-            intrinsics::EXP => Some(Instruction::PowF(a0, a1)),
+            intrinsics::POW => Some(Instruction::PowF(a0, a1)),
             intrinsics::MODULO => Some(Instruction::ModF(a0, a1)),
             intrinsics::LOG => Some(Instruction::LogF(a0, a1)),
             intrinsics::GT => Some(Instruction::Gt(a0, a1)),
@@ -320,7 +320,7 @@ impl Context {
         t: TypeNodeId,
         span: &Span,
     ) -> Result<VPtr, CompileError> {
-        log::debug!("rv t:{} {}", name.to_string(), t.to_type());
+        log::trace!("rv t:{} {}", name.to_string(), t.to_type());
         let v = match self.lookup(&name) {
             LookupRes::Local(v) => match v.as_ref() {
                 Value::Function(i) => {
@@ -650,7 +650,7 @@ impl Context {
             Expr::Let(pat, body, then) => {
                 if let Ok(tid) = TypedId::try_from(pat.clone()) {
                     self.fn_label = Some(tid.id);
-                    log::debug!(
+                    log::trace!(
                         "{}",
                         self.fn_label.map_or("".to_string(), |s| s.to_string())
                     )
@@ -661,7 +661,6 @@ impl Context {
                     self.get_current_basicblock().0.len()
                 };
                 let (bodyv, t) = self.eval_expr(*body)?;
-                log::debug!("let body: {}", t.to_type());
                 //todo:need to boolean and insert cast
                 self.fn_label = None;
 

--- a/mimium-lang/src/compiler/parser/test.rs
+++ b/mimium-lang/src/compiler/parser/test.rs
@@ -132,7 +132,7 @@ fn test_at() {
     test_string!("foo@1.0", ans1);
 
     let time = Expr::Apply(
-        Expr::Var("exp".to_symbol()).into_id(7..8),
+        Expr::Var("pow".to_symbol()).into_id(7..8),
         vec![
             Expr::Literal(Literal::Float("1.0".to_string())).into_id(4..7),
             Expr::Literal(Literal::Float("2.0".to_string())).into_id(8..11),

--- a/mimium-lang/src/compiler/parser/token.rs
+++ b/mimium-lang/src/compiler/parser/token.rs
@@ -107,7 +107,7 @@ impl Op {
             Op::GreaterThan => intrinsics::GT,
             Op::GreaterEqual => intrinsics::GE,
             Op::Modulo => intrinsics::MODULO,
-            Op::Exponent => intrinsics::EXP,
+            Op::Exponent => intrinsics::POW,
             Op::And => intrinsics::AND,
             Op::Or => intrinsics::OR,
             Op::At => "_mimium_schedule_at",

--- a/mimium-lang/src/compiler/typing.rs
+++ b/mimium-lang/src/compiler/typing.rs
@@ -119,7 +119,7 @@ impl InferContext {
             intrinsics::MULT,
             intrinsics::DIV,
             intrinsics::MODULO,
-            intrinsics::EXP,
+            intrinsics::POW,
             intrinsics::GT,
             intrinsics::LT,
             intrinsics::GE,
@@ -276,7 +276,7 @@ impl InferContext {
                 .map(|(v1, v2)| Self::unify_types(*v1, *v2, span.clone()))
                 .try_collect()
         };
-        log::debug!("unify {} and {}", t1.to_type(), t2.to_type());
+        log::trace!("unify {} and {}", t1.to_type(), t2.to_type());
         let t1r = t1.get_root();
         let t2r = t2.get_root();
         match &(t1r.to_type(), t2r.to_type()) {
@@ -585,7 +585,7 @@ impl InferContext {
                     self.infer_type(e)
                 })?;
                 let else_span = opt_else.map_or(span.end..span.end, |e| e.to_span());
-                log::debug!("then: {}, else: {}", thent.to_type(), elset.to_type());
+                log::trace!("then: {}, else: {}", thent.to_type(), elset.to_type());
                 Self::unify_types(thent, elset, else_span)
             }
             Expr::Block(expr) => expr.map_or(Ok(Type::Primitive(PType::Unit).into_id()), |e| {

--- a/mimium-lang/src/plugin/system_plugin.rs
+++ b/mimium-lang/src/plugin/system_plugin.rs
@@ -39,7 +39,9 @@ pub trait SystemPlugin {
     fn after_main(&mut self, _machine: &mut Machine) -> ReturnCode{
         0
     }
-    fn on_sample(&mut self, time: Time, machine: &mut Machine) -> ReturnCode;
+    fn on_sample(&mut self, _time: Time, _machine: &mut Machine) -> ReturnCode{
+        0
+    }
     fn gen_interfaces(&self) -> Vec<SysPluginSignature>;
 }
 #[derive(Clone)]

--- a/mimium-lang/src/plugin/system_plugin.rs
+++ b/mimium-lang/src/plugin/system_plugin.rs
@@ -33,7 +33,12 @@ impl SysPluginSignature {
 }
 
 pub trait SystemPlugin {
-    fn on_init(&mut self, machine: &mut Machine) -> ReturnCode;
+    fn on_init(&mut self, _machine: &mut Machine) -> ReturnCode{
+        0
+    }
+    fn after_main(&mut self, _machine: &mut Machine) -> ReturnCode{
+        0
+    }
     fn on_sample(&mut self, time: Time, machine: &mut Machine) -> ReturnCode;
     fn gen_interfaces(&self) -> Vec<SysPluginSignature>;
 }

--- a/mimium-lang/src/runtime/vm/builtin.rs
+++ b/mimium-lang/src/runtime/vm/builtin.rs
@@ -1,3 +1,4 @@
+use crate::compiler::ExtFunTypeInfo;
 use crate::interner::{Symbol, ToSymbol, TypeNodeId};
 use crate::types::{PType, Type};
 use crate::{function, numeric};
@@ -19,8 +20,22 @@ fn probelnf(machine: &mut Machine) -> ReturnCode {
     machine.set_stack(0, rv);
     1
 }
+fn min(machine: &mut Machine) -> ReturnCode {
+    let lhs = machine.get_stack(0);
+    let rhs = machine.get_stack(1);
 
-pub fn get_builtin_fns() -> [ExtFnInfo; 2] {
+    machine.set_stack(0, super::Machine::to_value(lhs.min(rhs)));
+    1
+}
+fn max(machine: &mut Machine) -> ReturnCode {
+    let lhs = machine.get_stack(0);
+    let rhs = machine.get_stack(1);
+
+    machine.set_stack(0, super::Machine::to_value(lhs.max(rhs)));
+    1
+}
+
+pub fn get_builtin_fns() -> [ExtFnInfo; 4] {
     [
         (
             "probe".to_symbol(),
@@ -32,12 +47,25 @@ pub fn get_builtin_fns() -> [ExtFnInfo; 2] {
             probelnf,
             function!(vec![numeric!()], numeric!()),
         ),
+        (
+            "min".to_symbol(),
+            min,
+            function!(vec![numeric!(), numeric!()], numeric!()),
+        ),
+        (
+            "max".to_symbol(),
+            max,
+            function!(vec![numeric!(), numeric!()], numeric!()),
+        ),
     ]
 }
 
-pub fn get_builtin_fn_types() -> Vec<(Symbol, TypeNodeId)> {
+pub fn get_builtin_fn_types() -> Vec<ExtFunTypeInfo> {
     get_builtin_fns()
         .iter()
-        .map(|(name, _f, t)| (*name, *t))
+        .map(|(name, _f, t)| ExtFunTypeInfo {
+            name: *name,
+            ty: *t,
+        })
         .collect()
 }

--- a/mimium-midi/Cargo.toml
+++ b/mimium-midi/Cargo.toml
@@ -10,6 +10,7 @@ build = "build.rs"
 
 
 [dependencies]
+log = "0.4.22"
 midir = "0.10.0"
 
 mimium-lang = { path = "../mimium-lang" }

--- a/mimium-midi/Cargo.toml
+++ b/mimium-midi/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "mimium-midi"
+version = "2.0.0-alpha-1"
+license = "MPL 2.0"
+edition = "2021"
+build = "build.rs"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+# [lib]
+
+
+[dependencies]
+midir = "0.10.0"
+
+mimium-lang = { path = "../mimium-lang" }
+
+[dev-dependencies]
+mimium-test = { path = "../mimium-test" }

--- a/mimium-midi/Cargo.toml
+++ b/mimium-midi/Cargo.toml
@@ -10,10 +10,12 @@ build = "build.rs"
 
 
 [dependencies]
+atomic_float = "1.1.0"
 log = "0.4.22"
 midir = "0.10.0"
 
 mimium-lang = { path = "../mimium-lang" }
+wmidi = "4.0.10"
 
 [dev-dependencies]
 mimium-test = { path = "../mimium-test" }

--- a/mimium-midi/build.rs
+++ b/mimium-midi/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("cargo:rustc-env=TEST_ROOT={}", env!("CARGO_MANIFEST_DIR"));
+}

--- a/mimium-midi/examples/midiin.mmm
+++ b/mimium-midi/examples/midiin.mmm
@@ -1,8 +1,91 @@
-midi_in_connect("device_name")
+let pi = 3.14159265359
+let sr = 48000.0
+let _ = set_midi_port("from Max 1")
+fn sec2samp(sec){
+    sec*48000.0
+}
+fn countup(active){
+    let r  =(self+1.0);
+    let rr = if (active) r else 0.0
+    rr
+}
+fn countupn(time,active){
+    let res = countup(active)
+    let r = if(res<time) res else 0.0
+    r
+}
+fn hold(time,active){
+    countupn(time,active)>0.0
+}
+fn get_gain(gate){
+    if (gate>0.1) gate else self
+}
+fn adsr(attack,decay,sustain,release,input){
+    let s = self
+    let atsig = min(1.0,(s + 1.0/sec2samp(attack)))
+    let decsig = max(sustain,(s-1.0/sec2samp(decay)))
+    let releasesig =max(0.0,(s-1.0/sec2samp(release)))
+    let at_or_dec = hold(sec2samp(attack),input>0.1)
+    let at_dec_sus_sig = if (at_or_dec>0.1) atsig else decsig
+    let res = if (input>0.1) at_dec_sus_sig else releasesig
+    res
+}
+fn phasor(freq){
+  (self + freq/sr)%1.0
+}
+fn osc(freq){
+  sin(phasor(freq)*pi*2.0)
+}
+fn midi_to_hz(note){
+    440.0*  (2.0 ^((note-69.0)/12.0))
+}
+let ch0  = bind_midi_note_mono( 0.0,69.0,0.0);
+let ch1  = bind_midi_note_mono( 1.0,69.0,0.0);
+let ch2  = bind_midi_note_mono( 2.0,69.0,0.0);
+let ch3  = bind_midi_note_mono( 3.0,69.0,0.0);
+let ch4  = bind_midi_note_mono( 4.0,69.0,0.0);
+let ch5  = bind_midi_note_mono( 5.0,69.0,0.0);
+let ch6  = bind_midi_note_mono( 6.0,69.0,0.0);
+let ch7  = bind_midi_note_mono( 7.0,69.0,0.0);
+let ch8  = bind_midi_note_mono( 8.0,69.0,0.0);
+let ch9  = bind_midi_note_mono( 9.0,69.0,0.0);
+let ch10 = bind_midi_note_mono(10.0,69.0,0.0);
+let ch11 = bind_midi_note_mono(11.0,69.0,0.0);
+let ch12 = bind_midi_note_mono(12.0,69.0,0.0);
+let ch13 = bind_midi_note_mono(13.0,69.0,0.0);
+let ch14 = bind_midi_note_mono(14.0,69.0,0.0);
+let ch15 = bind_midi_note_mono(15.0,69.0,0.0);
 
-    let note = (note,vel) 
-let note_manager = midi_in_bind_note(|chan,note,vel| {
-    |x| {
+fn myadsr(gate){
+    adsr(0.01,0.1,1.0,2.0,gate) *get_gain(gate)
 
-    }
-})
+}
+fn synth(midiv){
+    let (note,vel) = midiv
+    let sig = note |> midi_to_hz |> osc 
+    let gain = vel /127.0;
+    sig * ( gain |> myadsr )
+}
+
+
+fn dsp(){
+    let r_r =  (ch0() |> synth) + 
+                (ch1() |> synth) + 
+                 (ch2() |> synth) + 
+                  (ch3() |> synth) +
+                 (ch4() |> synth) + 
+                (ch5() |> synth) + 
+                 (ch6() |> synth) + 
+                  (ch7() |> synth)+
+                (ch8() |> synth) + 
+                 (ch9() |> synth) + 
+                  (ch10() |> synth) +
+                 (ch11() |> synth) + 
+                (ch12() |> synth) + 
+                 (ch13() |> synth) + 
+                  (ch14() |> synth)+
+                (ch15() |> synth)
+
+    let r = r_r/16.0
+    (r,r)
+}

--- a/mimium-midi/examples/midiin.mmm
+++ b/mimium-midi/examples/midiin.mmm
@@ -1,0 +1,8 @@
+midi_in_connect("device_name")
+
+    let note = (note,vel) 
+let note_manager = midi_in_bind_note(|chan,note,vel| {
+    |x| {
+
+    }
+})

--- a/mimium-midi/readme.md
+++ b/mimium-midi/readme.md
@@ -1,0 +1,30 @@
+# mimium MIDI Plugin
+
+MIDIPlugin provides 2APIs: `set_midi_port("port_name")` and `bind_midi_note_mono(channel,default_note,default_velocity)`.
+
+`bind_midi_note_mono` returns getter function of (float,float) value which is updated asynchronously by midi note event.
+
+(NoteOff is treated as NoteOn with 0 velocity).
+
+Processing for raw MIDI events like midi plugin in VST cannot be realized for now.
+
+(Note that MIDI devices are not available for WSL. I tested only on macOS.)
+
+
+```rust
+let _ = set_midi_port("from Max 1")
+fn osc(freq){
+   ...
+}
+fn midi_to_hz(note){
+    440.0*  (2.0 ^((note-69.0)/12.0))
+}
+let boundval = bind_midi_note_mono(0.0,69.0,127.0);
+fn dsp(){
+    let (note,vel) = boundval();
+
+    let sig = note |> midi_to_hz |> osc 
+    let r = sig * (vel /127.0);
+    (r,r)
+}
+```

--- a/mimium-midi/src/lib.rs
+++ b/mimium-midi/src/lib.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}

--- a/mimium-midi/src/lib.rs
+++ b/mimium-midi/src/lib.rs
@@ -1,5 +1,5 @@
 //! ## mimium MIDI Plugin
-//! 
+//!
 //! MIDI plugin currently implements a functionality for binding midi note signal to a tuple of float value.
 //! Processing for raw MIDI events like midi plugin in VST cannot be realized for now.
 
@@ -61,10 +61,11 @@ impl Default for MidiPlugin {
 }
 impl MidiPlugin {
     fn add_note_callback(&mut self, chan: u8, cb: NoteCallBack) {
-        if chan < 15 {
-            let _ = self.note_callbacks.as_mut().map(|v| {
+        match self.note_callbacks.as_mut() {
+            Some(v) if chan < 15 => {
                 v.0[chan as usize].push(cb);
-            });
+            }
+            _ => {}
         }
     }
     /// This function is exposed to mimium as "set_midi_port(port:string)".

--- a/mimium-midi/src/lib.rs
+++ b/mimium-midi/src/lib.rs
@@ -1,16 +1,58 @@
-use mimium_lang::{plugin::{SysPluginSignature, SystemPlugin}, runtime::{vm, Time}};
-use midir::MidiInput;
-pub struct MidiPlugin {
+use std::cell::OnceCell;
 
+use midir::{MidiInput, MidiInputPort};
+use mimium_lang::{
+    plugin::{SysPluginSignature, SystemPlugin},
+    runtime::{vm, Time},
+};
+pub struct MidiPlugin {
+    input: MidiInput,
+    port: OnceCell<MidiInputPort>,
+    port_name: Option<String>,
 }
 
-impl SystemPlugin for MidiPlugin{
-    fn on_init(&mut self, machine: &mut vm::Machine) ->vm::ReturnCode {
-        todo!()
+impl MidiPlugin {
+    pub fn try_new() -> Option<Self> {
+        let midiin = MidiInput::new("mimium midi plugin").ok();
+        midiin.map(|input| Self {
+            input,
+            port: OnceCell::new(),
+            port_name: None,
+        })
+    }
+}
+
+impl SystemPlugin for MidiPlugin {
+    fn after_main(&mut self, machine: &mut vm::Machine) -> vm::ReturnCode {
+        let mut ports = self.input.ports();
+        let port_opt = if let Some(pname) = &self.port_name {
+            let mut matchedports = ports.iter_mut().filter(|port| {
+                let name = self.input.port_name(port).unwrap_or_default();
+                &name == pname
+            });
+            matchedports.next()
+        } else {
+            ports.iter_mut().next()
+        };
+        port_opt.map(|p| {
+            let name = self.input.port_name(p).unwrap_or_default();
+            log::debug!("Midi Input: Connected to {name}");
+            // self.input.connect(
+            //     p,
+            //     &name,
+            //     |stamp, message, machine: &mut vm::Machine| {
+            //         todo!();
+            //     },
+            //     machine,
+            // );
+            self.port.set(p.clone());
+        });
+
+        0
     }
 
-    fn on_sample(&mut self, time:Time, machine: &mut vm::Machine) ->vm::ReturnCode {
-        todo!()
+    fn on_sample(&mut self, time: Time, machine: &mut vm::Machine) -> vm::ReturnCode {
+        0
     }
 
     fn gen_interfaces(&self) -> Vec<SysPluginSignature> {

--- a/mimium-midi/src/lib.rs
+++ b/mimium-midi/src/lib.rs
@@ -1,3 +1,19 @@
-fn main() {
-    println!("Hello, world!");
+use mimium_lang::{plugin::{SysPluginSignature, SystemPlugin}, runtime::{vm, Time}};
+use midir::MidiInput;
+pub struct MidiPlugin {
+
+}
+
+impl SystemPlugin for MidiPlugin{
+    fn on_init(&mut self, machine: &mut vm::Machine) ->vm::ReturnCode {
+        todo!()
+    }
+
+    fn on_sample(&mut self, time:Time, machine: &mut vm::Machine) ->vm::ReturnCode {
+        todo!()
+    }
+
+    fn gen_interfaces(&self) -> Vec<SysPluginSignature> {
+        todo!()
+    }
 }

--- a/mimium-midi/src/lib.rs
+++ b/mimium-midi/src/lib.rs
@@ -64,9 +64,14 @@ impl MidiPlugin {
         self.port_name = Some(ch.to_string());
         0
     }
+    /// This function is exposed to mimium as "bind_midi_note_mono".
+    /// Arguments: channel:float, default_note:freq, default:velocity
     pub fn bind_midi_note_mono(&mut self, vm: &mut vm::Machine) -> vm::ReturnCode {
         let ch = vm::Machine::get_as::<f64>(vm.get_stack(0));
-        let cell = Arc::new((AtomicF64::new(0.0), AtomicF64::new(0.0)));
+        let default_note = vm::Machine::get_as::<f64>(vm.get_stack(1));
+        let default_vel = vm::Machine::get_as::<f64>(vm.get_stack(2));
+
+        let cell = Arc::new((AtomicF64::new(default_note), AtomicF64::new(default_vel)));
         let cell_c = cell.clone();
         self.add_note_callback(
             ch as u8,
@@ -167,7 +172,7 @@ impl SystemPlugin for MidiPlugin {
 
     fn gen_interfaces(&self) -> Vec<SysPluginSignature> {
         let ty = function!(
-            vec![numeric!()],
+            vec![numeric!(),numeric!(),numeric!()],
             function!(vec![], tuple!(numeric!(), numeric!()))
         );
         let fun: fn(&mut Self, &mut vm::Machine) -> vm::ReturnCode = Self::bind_midi_note_mono;

--- a/mimium-midi/src/lib.rs
+++ b/mimium-midi/src/lib.rs
@@ -6,7 +6,7 @@ use mimium_lang::{
     numeric,
     plugin::{SysPluginSignature, SystemPlugin},
     runtime::{vm, Time},
-    string_t,
+    string_t, tuple,
     types::{PType, Type},
     unit,
 };
@@ -155,13 +155,16 @@ impl SystemPlugin for MidiPlugin {
     }
 
     fn gen_interfaces(&self) -> Vec<SysPluginSignature> {
-        let ty = function!(vec![numeric!()], function!(vec![], numeric!()));
-
-        let bindnote =
-            SysPluginSignature::new("bind_midi_note_mono", Self::bind_midi_note_mono, ty);
+        let ty = function!(
+            vec![numeric!()],
+            function!(vec![], tuple!(numeric!(), numeric!()))
+        );
+        let fun: fn(&mut Self, &mut vm::Machine) -> vm::ReturnCode = Self::bind_midi_note_mono;
+        let bindnote = SysPluginSignature::new("bind_midi_note_mono", fun, ty);
         let ty = function!(vec![string_t!()], unit!());
+        let fun: fn(&mut Self, &mut vm::Machine) -> vm::ReturnCode = Self::set_midi_port;
 
-        let setport = SysPluginSignature::new("set_midi_port", Self::set_midi_port, ty);
-        vec![bindnote, setport]
+        let setport = SysPluginSignature::new("set_midi_port", fun, ty);
+        vec![setport, bindnote]
     }
 }

--- a/mimium-midi/src/lib.rs
+++ b/mimium-midi/src/lib.rs
@@ -6,7 +6,9 @@ use mimium_lang::{
     numeric,
     plugin::{SysPluginSignature, SystemPlugin},
     runtime::{vm, Time},
+    string_t,
     types::{PType, Type},
+    unit,
 };
 use std::{
     cell::{OnceCell, RefCell},
@@ -52,7 +54,11 @@ impl MidiPlugin {
             });
         }
     }
-
+    pub fn set_midi_port(&mut self, vm: &mut vm::Machine) -> vm::ReturnCode {
+        let ch = vm::Machine::get_as::<&str>(vm.get_stack(0));
+        self.port_name = Some(ch.to_string());
+        0
+    }
     pub fn bind_midi_note_mono(&mut self, vm: &mut vm::Machine) -> vm::ReturnCode {
         let ch = vm::Machine::get_as::<f64>(vm.get_stack(0));
         let cell = Arc::new((AtomicF64::new(0.0), AtomicF64::new(0.0)));
@@ -149,6 +155,9 @@ impl SystemPlugin for MidiPlugin {
 
         let bindnote =
             SysPluginSignature::new("bind_midi_note_mono", Self::bind_midi_note_mono, ty);
-        vec![bindnote]
+        let ty = function!(vec![string_t!()], unit!());
+
+        let setport = SysPluginSignature::new("set_midi_port", Self::set_midi_port, ty);
+        vec![bindnote, setport]
     }
 }

--- a/mimium-midi/src/lib.rs
+++ b/mimium-midi/src/lib.rs
@@ -1,14 +1,28 @@
-use std::cell::OnceCell;
-
+use atomic_float::AtomicF64;
 use midir::{MidiInput, MidiInputPort};
 use mimium_lang::{
+    function,
+    interner::ToSymbol,
+    numeric,
     plugin::{SysPluginSignature, SystemPlugin},
     runtime::{vm, Time},
 };
+use std::{
+    cell::{OnceCell, RefCell},
+    rc::Rc,
+    sync::Arc,
+};
+
+type NoteCallBack = Box<dyn Fn(f64, f64) -> ()>;
+
+#[derive(Default)]
+struct NoteCallBacks(pub [Vec<NoteCallBack>; 16]);
+
 pub struct MidiPlugin {
     input: MidiInput,
     port: OnceCell<MidiInputPort>,
     port_name: Option<String>,
+    note_callbacks: NoteCallBacks,
 }
 
 impl MidiPlugin {
@@ -18,7 +32,39 @@ impl MidiPlugin {
             input,
             port: OnceCell::new(),
             port_name: None,
+            note_callbacks: Default::default(),
         })
+    }
+    fn add_note_callback(&mut self, chan: u8, cb: NoteCallBack) {
+        if chan < 15 {
+            self.note_callbacks.0[chan as usize].push(cb);
+        }
+    }
+    fn invoke_note_callback(&self, chan: u8, note: u8, vel: u8) {
+        if chan < 15 {
+            self.note_callbacks.0[chan as usize]
+                .iter()
+                .for_each(|cb| cb(note as f64, vel as f64));
+        }
+    }
+    pub fn bind_midi_note_mono(&mut self, vm: &mut vm::Machine) -> vm::ReturnCode {
+        let ch = vm::Machine::get_as::<f64>(vm.get_stack(0));
+        let cell = Arc::new((AtomicF64::new(), AtomicF64::new()));
+        self.add_note_callback(ch, |note, vel| {
+            let (note_c, vel_c) = cell.clone();
+            note_c.write(note);
+            vel_c.write(vel);
+        });
+        let cls = |vm: &mut vm::Machine| -> vm::ReturnCode {
+            let (note_c, vel_c) = cell.clone();
+            vm.set_stack(0, vm::Machine::to_value(note_c));
+            vm.set_stack(1, vm::Machine::to_value(vel_c));
+            2
+        };
+        let ty = function!(vec![], numeric!());
+        let rcls = vm.wrap_extern_cls(("get_midi_val".to_symbol(), Rc::new(RefCell::new(cls)), ty));
+        vm.set_stack(0, vm::Machine::to_value(rcls));
+        1
     }
 }
 
@@ -56,6 +102,10 @@ impl SystemPlugin for MidiPlugin {
     }
 
     fn gen_interfaces(&self) -> Vec<SysPluginSignature> {
-        todo!()
+        let ty = function!(vec![numeric!()], function!(vec![], numeric!()));
+
+        let bindnote =
+            SysPluginSignature::new("bind_midi_note_mono", Self::bind_midi_note_mono, ty);
+        vec![bindnote]
     }
 }

--- a/mimium-midi/tests/integration_test.rs
+++ b/mimium-midi/tests/integration_test.rs
@@ -1,0 +1,4 @@
+use midir::os::unix::{VirtualInput,VirtualOutput};
+use mimium_midi::MidiPlugin;
+use mimium_lang::plugin::Plugin;
+use mimium_test::*;

--- a/mimium-test/tests/intergration_test.rs
+++ b/mimium-test/tests/intergration_test.rs
@@ -321,3 +321,13 @@ fn include_file() {
     let ans = vec![0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0];
     assert_eq!(res, ans);
 }
+
+#[test]
+fn if_state() {
+    let res = run_file_test_stereo("if_state.mmm", 10).unwrap();
+    let ans = vec![
+        0.0, 0.0, 1.0, 0.0, 2.0, 0.0, 3.0, 0.0, 4.0, 0.0, 5.0, 0.0, 6.0, 0.0, 7.0, 0.0, 8.0, 0.0,
+        9.0, 0.0,
+    ];
+    assert_eq!(res, ans);
+}

--- a/mimium-test/tests/mmm/if_state.mmm
+++ b/mimium-test/tests/mmm/if_state.mmm
@@ -1,0 +1,8 @@
+fn countup(active){
+    let r  =(self+1.0);
+    let rr = if (active) r else 0.0
+    rr
+}
+fn dsp(){
+    (countup(1.0),countup(0.0))
+}


### PR DESCRIPTION
This PR implements experimental support for MIDI input devices.

MidiPlugin provides 2APIs: `set_midi_port("port_name")` and `bind_midi_note_mono(channel,default_note,default_velocity);`.

`bind_midi_note_mono` returns getter function of `(float,float)` value which is updated asynchronously by midi note event.(NoteOff is treated as NoteOn with 0 velocity).

Processing for raw MIDI events like midi plugin in VST cannot be realized for now.

(Note that MIDI device is not available for WSL. I tested only on macOS.)

```rust
let _ = set_midi_port("from Max 1")
fn osc(freq){
   ...
}
fn midi_to_hz(note){
    440.0*  (2.0 ^((note-69.0)/12.0))
}
let boundval = bind_midi_note_mono(0.0,69.0,127.0);
fn dsp(){
    let (note,vel) = boundval();

    let sig = note |> midi_to_hz |> osc 
    let r = sig * (vel /127.0);
    (r,r)
}
```