### PR TITLE
Allowing integer literal as numeric type value

### DIFF
--- a/mimium-lang/src/ast.rs
+++ b/mimium-lang/src/ast.rs
@@ -9,9 +9,9 @@ pub type Time = i64;
 
 #[derive(Clone, Debug, PartialEq, Hash)]
 pub enum Literal {
-    String(String),
+    String(Symbol),
     Int(i64),
-    Float(String),
+    Float(Symbol),
     SelfLit,
     Now,
     PlaceHolder,

--- a/mimium-lang/src/ast/builder.rs
+++ b/mimium-lang/src/ast/builder.rs
@@ -17,7 +17,7 @@ macro_rules! dummy_span {
 #[macro_export]
 macro_rules! number {
     ($n:literal) => {
-        Expr::Literal(Literal::Float($n.to_string())).into_id(0..0)
+        Expr::Literal(Literal::Float(crate::ast::builder::str_to_symbol($n))).into_id(0..0)
     };
 }
 

--- a/mimium-lang/src/ast_interpreter.rs
+++ b/mimium-lang/src/ast_interpreter.rs
@@ -106,9 +106,9 @@ const EXTERN_SYMS: [&str; 28] = [
 
 fn eval_literal(e: &ast::Literal) -> Value {
     match e {
-        ast::Literal::String(s) => Value::String(s.clone()),
+        ast::Literal::String(s) => Value::String(s.to_string()),
         ast::Literal::Int(i) => Value::Primitive(PValue::Integer(i.clone())),
-        ast::Literal::Float(f) => Value::Primitive(PValue::Numeric(f.parse().unwrap())),
+        ast::Literal::Float(f) => Value::Primitive(PValue::Numeric(f.as_str().parse().unwrap())),
         ast::Literal::SelfLit => {
             panic!("self literal should not be shown in evaluation stage.")
         }

--- a/mimium-lang/src/compiler/mirgen.rs
+++ b/mimium-lang/src/compiler/mirgen.rs
@@ -87,7 +87,7 @@ impl Context {
             Expr::Literal(Literal::Float(max)) => {
                 //need to evaluate args first before calculate state offset because the argument for time contains stateful function call.
                 let args = self.eval_args(&[*src, *time])?;
-                let max_time = max.parse::<f64>().unwrap();
+                let max_time = max.as_str().parse::<f64>().unwrap();
                 let shift_size = max_time as u64 + DELAY_ADDITIONAL_OFFSET;
                 self.get_current_fn().state_sizes.push(StateSize {
                     size: shift_size,
@@ -299,10 +299,10 @@ impl Context {
 
     pub fn eval_literal(&mut self, lit: &Literal, _span: &Span) -> Result<VPtr, CompileError> {
         let v = match lit {
-            Literal::String(s) => self.push_inst(Instruction::String((&s).to_symbol())),
+            Literal::String(s) => self.push_inst(Instruction::String(*s)),
             Literal::Int(i) => self.push_inst(Instruction::Integer(*i)),
             Literal::Float(f) => self.push_inst(Instruction::Float(
-                f.parse::<f64>().expect("illegal float format"),
+                f.as_str().parse::<f64>().expect("illegal float format"),
             )),
             Literal::Now => {
                 let ftype = numeric!();

--- a/mimium-lang/src/compiler/parser.rs
+++ b/mimium-lang/src/compiler/parser.rs
@@ -59,9 +59,11 @@ fn ident_parser() -> impl Parser<Token, Symbol, Error = Simple<Token>> + Clone {
 }
 fn literals_parser() -> impl Parser<Token, ExprNodeId, Error = Simple<Token>> + Clone {
     select! {
-        Token::Int(x) => Literal::Int(x),
-        Token::Float(x) =>Literal::Float(x.parse().unwrap()),
-        Token::Str(s) => Literal::String(s),
+        //Currently Integer literals are treated as float until the integer type is introduced in type system.
+        // Token::Int(x) => Literal::Int(x),
+        Token::Int(x)=>Literal::Float(x.to_string().to_symbol()),
+        Token::Float(x) =>Literal::Float(x.to_symbol()),
+        Token::Str(s) => Literal::String(s.to_symbol()),
         Token::SelfLit => Literal::SelfLit,
         Token::Now => Literal::Now,
         Token::PlaceHolder => Literal::PlaceHolder,

--- a/mimium-lang/src/compiler/parser/test.rs
+++ b/mimium-lang/src/compiler/parser/test.rs
@@ -30,7 +30,7 @@ fn test_let() {
             pat: Pattern::Single("goge".to_symbol()),
             ty: Type::Unknown.into_id_with_span(4..8),
         },
-        Expr::Literal(Literal::Int(36)).into_id(11..13),
+        Expr::Literal(Literal::Float("36".to_symbol())).into_id(11..13),
         Some(Expr::Var("goge".to_symbol()).into_id(15..19)),
     )
     .into_id(0..19);
@@ -47,8 +47,8 @@ fn test_lettuple() {
             ty: Type::Unknown.into_id_with_span(4..9),
         },
         Expr::Tuple(vec![
-            Expr::Literal(Literal::Int(36)).into_id(13..15),
-            Expr::Literal(Literal::Int(89)).into_id(16..18),
+            Expr::Literal(Literal::Float("36".to_symbol())).into_id(13..15),
+            Expr::Literal(Literal::Float("89".to_symbol())).into_id(16..18),
         ])
         .into_id(12..19),
         Some(Expr::Var("hoge".to_symbol()).into_id(21..25)),
@@ -59,7 +59,7 @@ fn test_lettuple() {
 #[test]
 fn test_if() {
     let ans = Expr::If(
-        Expr::Literal(Literal::Int(100)).into_id(4..7),
+        Expr::Literal(Literal::Float("100".to_symbol())).into_id(4..7),
         Expr::Var("hoge".to_symbol()).into_id(9..13),
         Some(Expr::Var("fuga".to_symbol()).into_id(19..23)),
     )
@@ -69,7 +69,7 @@ fn test_if() {
 #[test]
 fn test_if_noelse() {
     let ans = Expr::If(
-        Expr::Literal(Literal::Int(100)).into_id(4..7),
+        Expr::Literal(Literal::Float("100".to_symbol())).into_id(4..7),
         Expr::Var("hoge".to_symbol()).into_id(9..13),
         None,
     )
@@ -79,12 +79,12 @@ fn test_if_noelse() {
 
 #[test]
 fn test_int() {
-    let ans = Expr::Literal(Literal::Int(3466)).into_id(0..4);
+    let ans = Expr::Literal(Literal::Float("3466".to_symbol())).into_id(0..4);
     test_string!("3466", ans);
 }
 #[test]
 fn test_string() {
-    let ans = Expr::Literal(Literal::String("teststr".to_string())).into_id(0..9);
+    let ans = Expr::Literal(Literal::String("teststr".to_symbol())).into_id(0..9);
     test_string!("\"teststr\"", ans);
 }
 #[test]
@@ -95,7 +95,7 @@ fn test_block() {
                 pat: Pattern::Single("hoge".to_symbol()),
                 ty: Type::Unknown.into_id_with_span(5..9),
             },
-            Expr::Literal(Literal::Int(100)).into_id(12..15),
+            Expr::Literal(Literal::Float("100".to_symbol())).into_id(12..15),
             Some(Expr::Var("hoge".to_symbol()).into_id(16..20)),
         )
         .into_id(1..20),
@@ -112,8 +112,8 @@ fn test_add() {
     let ans = Expr::Apply(
         Expr::Var("add".to_symbol()).into_id(6..7),
         vec![
-            Expr::Literal(Literal::Float("3466.0".to_string())).into_id(0..6),
-            Expr::Literal(Literal::Float("2000.0".to_string())).into_id(7..13),
+            Expr::Literal(Literal::Float("3466.0".to_symbol())).into_id(0..6),
+            Expr::Literal(Literal::Float("2000.0".to_symbol())).into_id(7..13),
         ],
     )
     .into_id(0..13);
@@ -124,7 +124,7 @@ fn test_at() {
     let ans1 = Expr::Apply(
         Expr::Var("_mimium_schedule_at".to_symbol()).into_id(3..4),
         vec![
-            Expr::Literal(Literal::Float("1.0".to_string())).into_id(4..7),
+            Expr::Literal(Literal::Float("1.0".to_symbol())).into_id(4..7),
             Expr::Var("foo".to_symbol()).into_id(0..3),
         ],
     )
@@ -134,8 +134,8 @@ fn test_at() {
     let time = Expr::Apply(
         Expr::Var("pow".to_symbol()).into_id(7..8),
         vec![
-            Expr::Literal(Literal::Float("1.0".to_string())).into_id(4..7),
-            Expr::Literal(Literal::Float("2.0".to_string())).into_id(8..11),
+            Expr::Literal(Literal::Float("1.0".to_symbol())).into_id(4..7),
+            Expr::Literal(Literal::Float("2.0".to_symbol())).into_id(8..11),
         ],
     )
     .into_id(4..11);
@@ -182,7 +182,7 @@ fn test_assign2() {
             Expr::Var("fuga".to_symbol()).into_id(7..11),
         )
         .into_id(0..11),
-        Some(Expr::Literal(Literal::Float("100.0".to_string())).into_id(13..18)),
+        Some(Expr::Literal(Literal::Float("100.0".to_symbol())).into_id(13..18)),
     )
     .into_id(0..18);
     test_string!("hoge = fuga\n 100.0", ans);
@@ -351,8 +351,8 @@ fn test_macrodef() {
 #[test]
 fn test_tuple() {
     let tuple_items = vec![
-        Expr::Literal(Literal::Float("1.0".to_string())).into_id(1..4),
-        Expr::Literal(Literal::Float("2.0".to_string())).into_id(6..9),
+        Expr::Literal(Literal::Float("1.0".to_symbol())).into_id(1..4),
+        Expr::Literal(Literal::Float("2.0".to_symbol())).into_id(6..9),
     ];
 
     let ans = Expr::Tuple(tuple_items.clone()).into_id(0..10);
@@ -398,7 +398,7 @@ fn test_stmt_without_return() {
                     Expr::Var("add".to_symbol()).into_id(33..34),
                     vec![
                         Expr::Var("input".to_symbol()).into_id(28..33),
-                        Expr::Literal(Literal::Int(1)).into_id(34..35),
+                        Expr::Literal(Literal::Float("1".to_symbol())).into_id(34..35),
                     ],
                 )
                 .into_id(28..35),

--- a/mimium-test/tests/mmm/counter.mmm
+++ b/mimium-test/tests/mmm/counter.mmm
@@ -1,3 +1,3 @@
 fn dsp(){
- self+1.0
+ self+1
 }

--- a/mimium-test/tests/mmm/delay2.mmm
+++ b/mimium-test/tests/mmm/delay2.mmm
@@ -1,6 +1,6 @@
 fn counter(){
-    self+1.0
+    self+1
 }
 fn dsp(){
-    delay(10.0,counter(),5.0)
+    delay(10,counter(),5)
 }


### PR DESCRIPTION
This PR changes compiler's spec so that integer literals are treated as numeric type value.

If the integer types are introduced in the future, I will switch back this spec with implicit casting(or, introduces special suffix for explicit integer literal value declaration.)

Related to https://github.com/tomoyanonymous/mimium-rs/issues/59#issuecomment-2375850305