### PR TITLE
GUI Plot Plugin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1306,7 +1306,6 @@ name = "mimium-audiodriver"
 version = "2.0.0-alpha-1"
 dependencies = [
  "cpal",
- "log",
  "mimium-lang",
  "num-traits",
  "ringbuf",
@@ -1318,7 +1317,6 @@ version = "2.0.0-alpha-1"
 dependencies = [
  "clap",
  "colog",
- "log",
  "mimium-audiodriver",
  "mimium-lang",
  "mimium-midi",
@@ -1354,7 +1352,6 @@ name = "mimium-midi"
 version = "2.0.0-alpha-1"
 dependencies = [
  "atomic_float",
- "log",
  "midir",
  "mimium-lang",
  "mimium-test",
@@ -1373,7 +1370,6 @@ dependencies = [
 name = "mimium-symphonia"
 version = "2.0.0-alpha-1"
 dependencies = [
- "log",
  "mimium-lang",
  "mimium-test",
  "symphonia",
@@ -1383,7 +1379,6 @@ dependencies = [
 name = "mimium-test"
 version = "2.0.0-alpha-1"
 dependencies = [
- "log",
  "mimium-audiodriver",
  "mimium-lang",
  "mimium-scheduler",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1318,6 +1318,7 @@ dependencies = [
  "clap",
  "colog",
  "mimium-audiodriver",
+ "mimium-guitools",
  "mimium-lang",
  "mimium-midi",
  "mimium-scheduler",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,22 @@
 version = 3
 
 [[package]]
+name = "ab_glyph"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3672c180e71eeaaac3a541fbbc5f5ad4def8b747c595ad30d674e43049f7b0"
+dependencies = [
+ "ab_glyph_rasterizer",
+ "owned_ttf_parser",
+]
+
+[[package]]
+name = "ab_glyph_rasterizer"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c71b1793ee61086797f5c80b6efa2b8ffa6d5dd703f118545808a7f2e27f7046"
+
+[[package]]
 name = "ahash"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -404,10 +420,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
 
 [[package]]
+name = "ecolor"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "775cfde491852059e386c4e1deb4aef381c617dc364184c6f6afee99b87c402b"
+dependencies = [
+ "emath",
+]
+
+[[package]]
+name = "egui"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53eafabcce0cb2325a59a98736efe0bf060585b437763f8c476957fb274bb974"
+dependencies = [
+ "ahash",
+ "emath",
+ "epaint",
+ "nohash-hasher",
+]
+
+[[package]]
+name = "egui_plot"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8dca4871c15d51aadb79534dcf51a8189e5de3426ee7b465eb7db9a0a81ea67"
+dependencies = [
+ "ahash",
+ "egui",
+ "emath",
+]
+
+[[package]]
 name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+
+[[package]]
+name = "emath"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1fe0049ce51d0fb414d029e668dd72eb30bc2b739bf34296ed97bd33df544f3"
 
 [[package]]
 name = "encoding_rs"
@@ -440,6 +494,27 @@ dependencies = [
  "humantime",
  "log",
 ]
+
+[[package]]
+name = "epaint"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a32af8da821bd4f43f2c137e295459ee2e1661d87ca8779dfa0eaf45d870e20f"
+dependencies = [
+ "ab_glyph",
+ "ahash",
+ "ecolor",
+ "emath",
+ "epaint_default_fonts",
+ "nohash-hasher",
+ "parking_lot",
+]
+
+[[package]]
+name = "epaint_default_fonts"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "483440db0b7993cf77a20314f08311dbe95675092405518c0677aa08c151a3ea"
 
 [[package]]
 name = "equivalent"
@@ -648,6 +723,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "mimium-guitools"
+version = "2.0.0-alpha-1"
+dependencies = [
+ "egui",
+ "egui_plot",
+ "mimium-lang",
+]
+
+[[package]]
 name = "mimium-lang"
 version = "2.0.0-alpha-1"
 dependencies = [
@@ -735,6 +819,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "nohash-hasher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -813,6 +903,15 @@ name = "once_cell"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+
+[[package]]
+name = "owned_ttf_parser"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22ec719bbf3b2a81c109a4e20b1f129b5566b7dce654bc3872f6a05abf82b2c4"
+dependencies = [
+ "ttf-parser",
+]
 
 [[package]]
 name = "parking_lot"
@@ -1176,6 +1275,12 @@ dependencies = [
  "toml_datetime",
  "winnow",
 ]
+
+[[package]]
+name = "ttf-parser"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5902c5d130972a0000f60860bfbf46f7ca3db5391eddfedd1b8728bd9dc96c0e"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,13 +19,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c71b1793ee61086797f5c80b6efa2b8ffa6d5dd703f118545808a7f2e27f7046"
 
 [[package]]
+name = "accesskit"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99b76d84ee70e30a4a7e39ab9018e2b17a6a09e31084176cc7c0b2dec036ba45"
+dependencies = [
+ "enumn",
+ "serde",
+]
+
+[[package]]
+name = "adler2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+
+[[package]]
 name = "ahash"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
+ "getrandom",
  "once_cell",
+ "serde",
  "version_check",
  "zerocopy",
 ]
@@ -65,6 +83,33 @@ dependencies = [
  "libc",
  "pkg-config",
 ]
+
+[[package]]
+name = "android-activity"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef6978589202a00cd7e118380c448a08b6ed394c3a8df3a430d0898e3a42d046"
+dependencies = [
+ "android-properties",
+ "bitflags 2.6.0",
+ "cc",
+ "cesu8",
+ "jni",
+ "jni-sys",
+ "libc",
+ "log",
+ "ndk 0.9.0",
+ "ndk-context",
+ "ndk-sys 0.6.0+11769913",
+ "num_enum",
+ "thiserror",
+]
+
+[[package]]
+name = "android-properties"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7eb209b1518d6bb87b283c20095f5228ecda460da70b44f0802523dea6da04"
 
 [[package]]
 name = "anstream"
@@ -116,6 +161,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "arboard"
+version = "3.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df099ccb16cd014ff054ac1bf392c67feeef57164b05c42f037cd40f5d4357f4"
+dependencies = [
+ "clipboard-win",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+ "parking_lot",
+ "x11rb",
+]
+
+[[package]]
 name = "ariadne"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -132,6 +192,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "as-raw-xcb-connection"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175571dd1d178ced59193a6fc02dde1b972eb0bc56c892cde9beeceac5bf0f6b"
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "atomic_float"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -142,6 +214,12 @@ name = "autocfg"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+
+[[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "bindgen"
@@ -174,12 +252,24 @@ name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "block"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
+
+[[package]]
+name = "block2"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
+dependencies = [
+ "objc2",
+]
 
 [[package]]
 name = "bumpalo"
@@ -192,12 +282,58 @@ name = "bytemuck"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94bbb0ad554ad961ddc5da507a12a29b14e4ae5bda06b19f575a3e6079d2e2ae"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcfcc3cd946cb52f0bbfdbbcfa2f4e24f75ebb6c0e1002f7c25904fada18b9ec"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a12916984aab3fa6e39d655a33e09c0071eb36d6ab3aea5c2d78551f1df6d952"
+
+[[package]]
+name = "calloop"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b99da2f8558ca23c71f4fd15dc57c906239752dd27ff3c00a1d56b685b7cbfec"
+dependencies = [
+ "bitflags 2.6.0",
+ "log",
+ "polling",
+ "rustix",
+ "slab",
+ "thiserror",
+]
+
+[[package]]
+name = "calloop-wayland-source"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95a66a987056935f7efce4ab5668920b5d0dac4a7c99991a67395f13702ddd20"
+dependencies = [
+ "calloop",
+ "rustix",
+ "wayland-backend",
+ "wayland-client",
+]
 
 [[package]]
 name = "cc"
@@ -229,6 +365,21 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "cgl"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ced0551234e87afee12411d535648dd89d2e7f34c78b753395567aff3d447ff"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "chumsky"
@@ -291,6 +442,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
 
 [[package]]
+name = "clipboard-win"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15efe7a882b08f34e38556b14f2fb3daa98769d06c7f0c1b076dfd0d983bc892"
+dependencies = [
+ "error-code",
+]
+
+[[package]]
 name = "colog"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -328,6 +488,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -342,6 +511,30 @@ name = "core-foundation-sys"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
+
+[[package]]
+name = "core-graphics"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c07782be35f9e1140080c6b96f0d44b739e2278479f64e02fdab4e32dfd8b081"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "core-graphics-types",
+ "foreign-types",
+ "libc",
+]
+
+[[package]]
+name = "core-graphics-types"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "libc",
+]
 
 [[package]]
 name = "coreaudio-rs"
@@ -398,7 +591,7 @@ dependencies = [
  "js-sys",
  "libc",
  "mach2",
- "ndk",
+ "ndk 0.8.0",
  "ndk-context",
  "oboe",
  "wasm-bindgen",
@@ -408,10 +601,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+
+[[package]]
+name = "cursor-icon"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96a6ac251f4a2aca6b3f91340350eab87ae57c3f127ffeb585e92bd336717991"
 
 [[package]]
 name = "dasp_sample"
@@ -420,12 +628,87 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
 
 [[package]]
+name = "dispatch"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
+
+[[package]]
+name = "dlib"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
+dependencies = [
+ "libloading",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb6969eaabd2421f8a2775cfd2471a2b634372b4a25d41e3bd647b79912850a0"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
+name = "dpi"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f25c0e292a7ca6d6498557ff1df68f32c99850012b6ea401cf8daf771f22ff53"
+
+[[package]]
 name = "ecolor"
 version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "775cfde491852059e386c4e1deb4aef381c617dc364184c6f6afee99b87c402b"
 dependencies = [
+ "bytemuck",
  "emath",
+ "serde",
+]
+
+[[package]]
+name = "eframe"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ac2645a9bf4826eb4e91488b1f17b8eaddeef09396706b2f14066461338e24f"
+dependencies = [
+ "ahash",
+ "bytemuck",
+ "document-features",
+ "egui",
+ "egui-winit",
+ "egui_glow",
+ "glow",
+ "glutin",
+ "glutin-winit",
+ "home",
+ "image",
+ "js-sys",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+ "parking_lot",
+ "percent-encoding",
+ "raw-window-handle",
+ "ron",
+ "serde",
+ "static_assertions",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "web-time",
+ "winapi",
+ "windows-sys 0.52.0",
+ "winit",
 ]
 
 [[package]]
@@ -434,10 +717,48 @@ version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53eafabcce0cb2325a59a98736efe0bf060585b437763f8c476957fb274bb974"
 dependencies = [
+ "accesskit",
  "ahash",
  "emath",
  "epaint",
+ "log",
  "nohash-hasher",
+ "ron",
+ "serde",
+]
+
+[[package]]
+name = "egui-winit"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a9c430f4f816340e8e8c1b20eec274186b1be6bc4c7dfc467ed50d57abc36c6"
+dependencies = [
+ "ahash",
+ "arboard",
+ "egui",
+ "log",
+ "raw-window-handle",
+ "serde",
+ "smithay-clipboard",
+ "web-time",
+ "webbrowser",
+ "winit",
+]
+
+[[package]]
+name = "egui_glow"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e39bccc683cd43adab530d8f21a13eb91e80de10bcc38c3f1c16601b6f62b26"
+dependencies = [
+ "ahash",
+ "bytemuck",
+ "egui",
+ "glow",
+ "log",
+ "memoffset",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -462,6 +783,10 @@ name = "emath"
 version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1fe0049ce51d0fb414d029e668dd72eb30bc2b739bf34296ed97bd33df544f3"
+dependencies = [
+ "bytemuck",
+ "serde",
+]
 
 [[package]]
 name = "encoding_rs"
@@ -470,6 +795,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "enumn"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f9ed6b3789237c8a0c1c505af1c7eb2c560df6186f01b098c3a1064ea532f38"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -503,11 +839,14 @@ checksum = "a32af8da821bd4f43f2c137e295459ee2e1661d87ca8779dfa0eaf45d870e20f"
 dependencies = [
  "ab_glyph",
  "ahash",
+ "bytemuck",
  "ecolor",
  "emath",
  "epaint_default_fonts",
+ "log",
  "nohash-hasher",
  "parking_lot",
+ "serde",
 ]
 
 [[package]]
@@ -523,16 +862,197 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
+name = "errno"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "error-code"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d9305ccc6942a704f4335694ecd3de2ea531b114ac2d51f5f843750787a92f"
+
+[[package]]
 name = "extended"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af9673d8203fcb076b19dfd17e38b3d4ae9f44959416ea532ce72415a6020365"
 
 [[package]]
+name = "fdeflate"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07c6f4c64c1d33a3111c4466f7365ebdcc37c5bd1ea0d62aae2e3d722aacbedb"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
+name = "flate2"
+version = "1.0.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1b589b4dc103969ad3cf85c950899926ec64300a1a46d76c03a6072957036f0"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "foreign-types"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
+dependencies = [
+ "foreign-types-macros",
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-macros"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "gethostname"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0176e0459c2e4a1fe232f984bca6890e681076abb9934f6cea7c326f3fc47818"
+dependencies = [
+ "libc",
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "gl_generator"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a95dfc23a2b4a9a2f5ab41d194f8bfda3cabec42af4e39f08c339eb2a0c124d"
+dependencies = [
+ "khronos_api",
+ "log",
+ "xml-rs",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
+name = "glow"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d51fa363f025f5c111e03f13eda21162faeacb6911fe8caa0c0349f9cf0c4483"
+dependencies = [
+ "js-sys",
+ "slotmap",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "glutin"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec69412a0bf07ea7607e638b415447857a808846c2b685a43c8aa18bc6d5e499"
+dependencies = [
+ "bitflags 2.6.0",
+ "cfg_aliases",
+ "cgl",
+ "core-foundation",
+ "dispatch",
+ "glutin_egl_sys",
+ "glutin_glx_sys",
+ "glutin_wgl_sys",
+ "libloading",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+ "once_cell",
+ "raw-window-handle",
+ "wayland-sys",
+ "windows-sys 0.52.0",
+ "x11-dl",
+]
+
+[[package]]
+name = "glutin-winit"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85edca7075f8fc728f28cb8fbb111a96c3b89e930574369e3e9c27eb75d3788f"
+dependencies = [
+ "cfg_aliases",
+ "glutin",
+ "raw-window-handle",
+ "winit",
+]
+
+[[package]]
+name = "glutin_egl_sys"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cae99fff4d2850dbe6fb8c1fa8e4fead5525bab715beaacfccf3fb994e01c827"
+dependencies = [
+ "gl_generator",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "glutin_glx_sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c2b2d3918e76e18e08796b55eb64e8fe6ec67d5a6b2e2a7e2edce224ad24c63"
+dependencies = [
+ "gl_generator",
+ "x11-dl",
+]
+
+[[package]]
+name = "glutin_wgl_sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a4e1951bbd9434a81aa496fe59ccc2235af3820d27b85f9314e279609211e2c"
+dependencies = [
+ "gl_generator",
+]
 
 [[package]]
 name = "hashbrown"
@@ -551,10 +1071,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
+
+[[package]]
+name = "home"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "idna"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "image"
+version = "0.25.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc144d44a31d753b02ce64093d532f55ff8dc4ebf2ffb8a63c0dda691385acae"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "num-traits",
+ "png",
+]
 
 [[package]]
 name = "indexmap"
@@ -614,12 +1171,18 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.69"
+version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
+checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
 dependencies = [
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "khronos_api"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
 name = "lazy_static"
@@ -635,9 +1198,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.126"
+version = "0.2.161"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
+checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
 
 [[package]]
 name = "libloading"
@@ -648,6 +1211,29 @@ dependencies = [
  "cfg-if",
  "windows-targets 0.52.5",
 ]
+
+[[package]]
+name = "libredox"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+dependencies = [
+ "bitflags 2.6.0",
+ "libc",
+ "redox_syscall 0.5.7",
+]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+
+[[package]]
+name = "litrs"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5"
 
 [[package]]
 name = "lock_api"
@@ -679,6 +1265,24 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "memmap2"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd3f7eed9d3848f8b98834af67102b720745c4ec028fcd0aa0239277e7de374f"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "midir"
@@ -726,9 +1330,11 @@ dependencies = [
 name = "mimium-guitools"
 version = "2.0.0-alpha-1"
 dependencies = [
+ "eframe",
  "egui",
  "egui_plot",
  "mimium-lang",
+ "ringbuf",
 ]
 
 [[package]]
@@ -790,6 +1396,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "ndk"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -798,8 +1414,23 @@ dependencies = [
  "bitflags 2.6.0",
  "jni-sys",
  "log",
- "ndk-sys",
+ "ndk-sys 0.5.0+25.2.9519653",
  "num_enum",
+ "thiserror",
+]
+
+[[package]]
+name = "ndk"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
+dependencies = [
+ "bitflags 2.6.0",
+ "jni-sys",
+ "log",
+ "ndk-sys 0.6.0+11769913",
+ "num_enum",
+ "raw-window-handle",
  "thiserror",
 ]
 
@@ -814,6 +1445,15 @@ name = "ndk-sys"
 version = "0.5.0+25.2.9519653"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c196769dd60fd4f363e11d948139556a344e79d451aeb2fa2fd040738ef7691"
+dependencies = [
+ "jni-sys",
+]
+
+[[package]]
+name = "ndk-sys"
+version = "0.6.0+11769913"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
 dependencies = [
  "jni-sys",
 ]
@@ -876,13 +1516,216 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc-sys"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb91bdd390c7ce1a8607f35f3ca7151b65afc0ff5ff3b34fa350f7d7c7e4310"
+
+[[package]]
+name = "objc2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a785d4eeff09c14c487497c162e92766fbb3e4059a71840cecc03d9a50b804"
+dependencies = [
+ "objc-sys",
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-app-kit"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff"
+dependencies = [
+ "bitflags 2.6.0",
+ "block2",
+ "libc",
+ "objc2",
+ "objc2-core-data",
+ "objc2-core-image",
+ "objc2-foundation",
+ "objc2-quartz-core",
+]
+
+[[package]]
+name = "objc2-cloud-kit"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74dd3b56391c7a0596a295029734d3c1c5e7e510a4cb30245f8221ccea96b009"
+dependencies = [
+ "bitflags 2.6.0",
+ "block2",
+ "objc2",
+ "objc2-core-location",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-contacts"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5ff520e9c33812fd374d8deecef01d4a840e7b41862d849513de77e44aa4889"
+dependencies = [
+ "block2",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
+dependencies = [
+ "bitflags 2.6.0",
+ "block2",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-image"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55260963a527c99f1819c4f8e3b47fe04f9650694ef348ffd2227e8196d34c80"
+dependencies = [
+ "block2",
+ "objc2",
+ "objc2-foundation",
+ "objc2-metal",
+]
+
+[[package]]
+name = "objc2-core-location"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "000cfee34e683244f284252ee206a27953279d370e309649dc3ee317b37e5781"
+dependencies = [
+ "block2",
+ "objc2",
+ "objc2-contacts",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7891e71393cd1f227313c9379a26a584ff3d7e6e7159e988851f0934c993f0f8"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
+dependencies = [
+ "bitflags 2.6.0",
+ "block2",
+ "dispatch",
+ "libc",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-link-presentation"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1a1ae721c5e35be65f01a03b6d2ac13a54cb4fa70d8a5da293d7b0020261398"
+dependencies = [
+ "block2",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-metal"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
+dependencies = [
+ "bitflags 2.6.0",
+ "block2",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
+dependencies = [
+ "bitflags 2.6.0",
+ "block2",
+ "objc2",
+ "objc2-foundation",
+ "objc2-metal",
+]
+
+[[package]]
+name = "objc2-symbols"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a684efe3dec1b305badae1a28f6555f6ddd3bb2c2267896782858d5a78404dc"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-ui-kit"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8bb46798b20cd6b91cbd113524c490f1686f4c4e8f49502431415f3512e2b6f"
+dependencies = [
+ "bitflags 2.6.0",
+ "block2",
+ "objc2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
+ "objc2-core-image",
+ "objc2-core-location",
+ "objc2-foundation",
+ "objc2-link-presentation",
+ "objc2-quartz-core",
+ "objc2-symbols",
+ "objc2-uniform-type-identifiers",
+ "objc2-user-notifications",
+]
+
+[[package]]
+name = "objc2-uniform-type-identifiers"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44fa5f9748dbfe1ca6c0b79ad20725a11eca7c2218bceb4b005cb1be26273bfe"
+dependencies = [
+ "block2",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-user-notifications"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76cfcbf642358e8689af64cee815d139339f3ed8ad05103ed5eaf73db8d84cb3"
+dependencies = [
+ "bitflags 2.6.0",
+ "block2",
+ "objc2",
+ "objc2-core-location",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "oboe"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8b61bebd49e5d43f5f8cc7ee2891c16e0f41ec7954d36bcb6c14c5e0de867fb"
 dependencies = [
  "jni",
- "ndk",
+ "ndk 0.8.0",
  "ndk-context",
  "num-derive",
  "num-traits",
@@ -903,6 +1746,15 @@ name = "once_cell"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+
+[[package]]
+name = "orbclient"
+version = "0.3.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba0b26cec2e24f08ed8bb31519a9333140a6599b867dac464bb150bdb796fd43"
+dependencies = [
+ "libredox",
+]
 
 [[package]]
 name = "owned_ttf_parser"
@@ -931,16 +1783,82 @@ checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.7",
  "smallvec",
  "windows-targets 0.52.5",
 ]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "pin-project"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be57f64e946e500c8ee36ef6331845d40a93055567ec57e8fae13efd33759b95"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c0f5fad0874fc7abcd4d750e76917eaebbecaa2c20bde22e1dbeeba8beb758c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
 
 [[package]]
 name = "pkg-config"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
+
+[[package]]
+name = "png"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f9d46a34a05a6a57566bc2bfae066ef07585a6e3fa30fbbdff5936380623f0"
+dependencies = [
+ "bitflags 1.3.2",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "polling"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3ed00ed3fbf728b5816498ecd316d1716eecaced9c0c8d2c5a6740ca214985b"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "portable-atomic"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc9c68a3f6da06753e9335d63e27f6b9754dd1920d941135b7ea8224f141adb2"
 
 [[package]]
 name = "proc-macro-crate"
@@ -961,12 +1879,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.36.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7649a7b4df05aed9ea7ec6f628c67c9953a43869b8bc50929569b2999d443fe"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "raw-window-handle"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
+
+[[package]]
+name = "redox_syscall"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+dependencies = [
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -1009,11 +1951,24 @@ checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "ringbuf"
-version = "0.4.1"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c65e4c865bc3d2e3294493dff0acf7e6c259d066e34e22059fa9c39645c3636"
+checksum = "726bb493fe9cac765e8f96a144c3a8396bdf766dedad22e504b70b908dcbceb4"
 dependencies = [
  "crossbeam-utils",
+ "portable-atomic",
+]
+
+[[package]]
+name = "ron"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
+dependencies = [
+ "base64",
+ "bitflags 2.6.0",
+ "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -1023,6 +1978,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustix"
+version = "0.38.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa260229e6538e52293eeb577aabd09945a09d6d9cc0fc550ed7529056c2e32a"
+dependencies = [
+ "bitflags 2.6.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1030,6 +1998,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -1064,6 +2038,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+
+[[package]]
+name = "slab"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "slotmap"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1077,6 +2066,57 @@ name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+
+[[package]]
+name = "smithay-client-toolkit"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3457dea1f0eb631b4034d61d4d8c32074caa6cd1ab2d59f2327bd8461e2c0016"
+dependencies = [
+ "bitflags 2.6.0",
+ "calloop",
+ "calloop-wayland-source",
+ "cursor-icon",
+ "libc",
+ "log",
+ "memmap2",
+ "rustix",
+ "thiserror",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-csd-frame",
+ "wayland-cursor",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
+ "wayland-scanner",
+ "xkeysym",
+]
+
+[[package]]
+name = "smithay-clipboard"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc8216eec463674a0e90f29e0ae41a4db573ec5b56b1c6c1c71615d249b6d846"
+dependencies = [
+ "libc",
+ "smithay-client-toolkit",
+ "wayland-backend",
+]
+
+[[package]]
+name = "smol_str"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd538fb6910ac1099850255cf94a94df6551fbdd602454387d0adb2d1ca6dead"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "string-interner"
@@ -1260,6 +2300,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1277,10 +2332,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing"
+version = "0.1.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+dependencies = [
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+
+[[package]]
 name = "ttf-parser"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5902c5d130972a0000f60860bfbf46f7ca3db5391eddfedd1b8728bd9dc96c0e"
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ab17db44d7388991a428b2ee655ce0c212e862eff1768a455c58f9aad6e7893"
 
 [[package]]
 name = "unicode-ident"
@@ -1289,10 +2366,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
+name = "unicode-normalization"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
 name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "url"
+version = "2.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+]
 
 [[package]]
 name = "utf8parse"
@@ -1317,20 +2420,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen"
-version = "0.2.92"
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e"
 dependencies = [
  "cfg-if",
+ "once_cell",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.92"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
+checksum = "cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358"
 dependencies = [
  "bumpalo",
  "log",
@@ -1355,9 +2465,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.92"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
+checksum = "e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1365,9 +2475,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.92"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
+checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1378,19 +2488,172 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.92"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
+
+[[package]]
+name = "wayland-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "056535ced7a150d45159d3a8dc30f91a2e2d588ca0b23f70e56033622b8016f6"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "rustix",
+ "scoped-tls",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66249d3fc69f76fd74c82cc319300faa554e9d865dab1f7cd66cc20db10b280"
+dependencies = [
+ "bitflags 2.6.0",
+ "rustix",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-csd-frame"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625c5029dbd43d25e6aa9615e88b829a5cad13b2819c4ae129fdbb7c31ab4c7e"
+dependencies = [
+ "bitflags 2.6.0",
+ "cursor-icon",
+ "wayland-backend",
+]
+
+[[package]]
+name = "wayland-cursor"
+version = "0.31.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32b08bc3aafdb0035e7fe0fdf17ba0c09c268732707dca4ae098f60cb28c9e4c"
+dependencies = [
+ "rustix",
+ "wayland-client",
+ "xcursor",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.32.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd0ade57c4e6e9a8952741325c30bf82f4246885dca8bf561898b86d0c1f58e"
+dependencies = [
+ "bitflags 2.6.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-plasma"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b31cab548ee68c7eb155517f2212049dc151f7cd7910c2b66abfd31c3ee12bd"
+dependencies = [
+ "bitflags 2.6.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-wlr"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "782e12f6cd923c3c316130d56205ebab53f55d6666b7faddfad36cecaeeb4022"
+dependencies = [
+ "bitflags 2.6.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597f2001b2e5fc1121e3d5b9791d3e78f05ba6bfa4641053846248e3a13661c3"
+dependencies = [
+ "proc-macro2",
+ "quick-xml",
+ "quote",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efa8ac0d8e8ed3e3b5c9fc92c7881406a268e11555abe36493efabe649a29e09"
+dependencies = [
+ "dlib",
+ "log",
+ "once_cell",
+ "pkg-config",
+]
 
 [[package]]
 name = "web-sys"
-version = "0.3.69"
+version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
+checksum = "f6488b90108c040df0fe62fa815cbdee25124641df01814dd7282749234c6112"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webbrowser"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "425ba64c1e13b1c6e8c5d2541c8fac10022ca584f33da781db01b5756aef1f4e"
+dependencies = [
+ "block2",
+ "core-foundation",
+ "home",
+ "jni",
+ "log",
+ "ndk-context",
+ "objc2",
+ "objc2-foundation",
+ "url",
+ "web-sys",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
@@ -1400,6 +2663,12 @@ checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
 dependencies = [
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
@@ -1680,6 +2949,57 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
 
 [[package]]
+name = "winit"
+version = "0.30.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be9e76a1f1077e04a411f0b989cbd3c93339e1771cb41e71ac4aee95bfd2c67"
+dependencies = [
+ "ahash",
+ "android-activity",
+ "atomic-waker",
+ "bitflags 2.6.0",
+ "block2",
+ "bytemuck",
+ "calloop",
+ "cfg_aliases",
+ "concurrent-queue",
+ "core-foundation",
+ "core-graphics",
+ "cursor-icon",
+ "dpi",
+ "js-sys",
+ "libc",
+ "memmap2",
+ "ndk 0.9.0",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+ "objc2-ui-kit",
+ "orbclient",
+ "percent-encoding",
+ "pin-project",
+ "raw-window-handle",
+ "redox_syscall 0.4.1",
+ "rustix",
+ "smithay-client-toolkit",
+ "smol_str",
+ "tracing",
+ "unicode-segmentation",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-protocols-plasma",
+ "web-sys",
+ "web-time",
+ "windows-sys 0.52.0",
+ "x11-dl",
+ "x11rb",
+ "xkbcommon-dl",
+]
+
+[[package]]
 name = "winnow"
 version = "0.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1693,6 +3013,69 @@ name = "wmidi"
 version = "4.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e55f35b40ad0178422d06e9ba845041baf2faf04627b91fde928d0f6a21c712"
+
+[[package]]
+name = "x11-dl"
+version = "2.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38735924fedd5314a6e548792904ed8c6de6636285cb9fec04d5b1db85c1516f"
+dependencies = [
+ "libc",
+ "once_cell",
+ "pkg-config",
+]
+
+[[package]]
+name = "x11rb"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8f25ead8c7e4cba123243a6367da5d3990e0d3affa708ea19dce96356bd9f1a"
+dependencies = [
+ "as-raw-xcb-connection",
+ "gethostname",
+ "libc",
+ "libloading",
+ "once_cell",
+ "rustix",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec107c4503ea0b4a98ef47356329af139c0a4f7750e621cf2973cd3385ebcb3d"
+
+[[package]]
+name = "xcursor"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ef33da6b1660b4ddbfb3aef0ade110c8b8a781a3b6382fa5f2b5b040fd55f61"
+
+[[package]]
+name = "xkbcommon-dl"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d039de8032a9a8856a6be89cea3e5d12fdd82306ab7c94d74e6deab2460651c5"
+dependencies = [
+ "bitflags 2.6.0",
+ "dlib",
+ "log",
+ "once_cell",
+ "xkeysym",
+]
+
+[[package]]
+name = "xkeysym"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
+
+[[package]]
+name = "xml-rs"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af4e2e2f7cba5a093896c1e150fbfe177d1883e7448200efb81d40b9d339ef26"
 
 [[package]]
 name = "yansi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
     "mimium-test",
     "mimium-scheduler",
     "mimium-symphonia",
-    "mimium-midi",
+    "mimium-midi", "mimium-guitools",
 ]
 
 resolver = "2"

--- a/mimium-audiodriver/Cargo.toml
+++ b/mimium-audiodriver/Cargo.toml
@@ -10,7 +10,6 @@ edition = "2021"
 
 [dependencies]
 cpal = "0.15.3"
-log = "0.4.22"
 num-traits = "0.2.19"
 ringbuf = "0.4.1"
 mimium-lang = {path = "../mimium-lang"}

--- a/mimium-audiodriver/src/backends/cpal.rs
+++ b/mimium-audiodriver/src/backends/cpal.rs
@@ -8,6 +8,7 @@ use mimium_lang::runtime::{vm, Time};
 use mimium_lang::ExecContext;
 use ringbuf::traits::{Consumer, Producer, Split};
 use ringbuf::{HeapCons, HeapProd, HeapRb};
+use mimium_lang::log;
 const BUFFER_RATIO: usize = 2;
 pub struct NativeDriver {
     sr: SampleRate,

--- a/mimium-audiodriver/src/backends/cpal.rs
+++ b/mimium-audiodriver/src/backends/cpal.rs
@@ -240,7 +240,6 @@ impl Driver for NativeDriver {
         let odevice = host.default_output_device();
         let out_stream = if let Some(odevice) = odevice {
             let mut processor = NativeAudioData::new(ctx, cons, self.count.clone());
-            processor.vmdata.run_main();
             let mut oconfig = Self::init_oconfig(&odevice, sample_rate);
             oconfig.buffer_size = cpal::BufferSize::Fixed((self.buffer_size / BUFFER_RATIO) as u32);
             log::info!(

--- a/mimium-audiodriver/src/driver.rs
+++ b/mimium-audiodriver/src/driver.rs
@@ -91,6 +91,9 @@ impl RuntimeData {
             dsp_i,
         }
     }
+
+    /// warn: Currently duplicated with ExecContext::run_main.
+    /// only LocalBufferDriver uses this function.
     pub fn run_main(&mut self) -> ReturnCode {
         self.sys_plugins.iter().for_each(|plug: &DynSystemPlugin| {
             //todo: encapsulate unsafety within SystemPlugin functionality

--- a/mimium-audiodriver/src/driver.rs
+++ b/mimium-audiodriver/src/driver.rs
@@ -55,12 +55,13 @@ impl ReportableError for Error {
     }
 }
 
-// Note: `Driver` trait doesn't have `new()` so that the struct can have its own
-// `new()` with any parameters specific to the type. With this in mind, `init()`
-// can accept only common parameters.
+/// Note: `Driver` trait doesn't have `new()` so that the struct can have its own
+/// `new()` with any parameters specific to the type. With this in mind, `init()`
+/// can accept only common parameters.
 pub trait Driver {
     type Sample: Float;
     fn get_runtimefn_infos(&self) -> Vec<ExtClsInfo>;
+    /// Call ctx.run_main() before moving ctx to Driver with this function.
     fn init(&mut self, ctx: ExecContext, sample_rate: Option<SampleRate>) -> bool;
     fn play(&mut self) -> bool;
     fn pause(&mut self) -> bool;

--- a/mimium-cli/Cargo.toml
+++ b/mimium-cli/Cargo.toml
@@ -12,7 +12,6 @@ repository = "https://github.com/tomoyanonymous/mimium-rs/"
 [dependencies]
 
 clap = { version = "4.5.7", features = ["derive"] }
-log = "0.4.22"
 
 mimium-lang = { path = "../mimium-lang" }
 mimium-audiodriver = { path = "../mimium-audiodriver" }

--- a/mimium-cli/Cargo.toml
+++ b/mimium-cli/Cargo.toml
@@ -18,4 +18,5 @@ mimium-audiodriver = { path = "../mimium-audiodriver" }
 mimium-midi = { path = "../mimium-midi" }
 mimium-symphonia = { path = "../mimium-symphonia" }
 mimium-scheduler = { path = "../mimium-scheduler" }
+mimium-guitools = { path = "../mimium-guitools" }
 colog = "1.3.0"

--- a/mimium-cli/src/main.rs
+++ b/mimium-cli/src/main.rs
@@ -15,6 +15,7 @@ use mimium_lang::ExecContext;
 use mimium_lang::{compiler::mirgen::convert_pronoun, repl};
 use mimium_midi;
 use mimium_symphonia::{self, SamplerPlugin};
+use mimium_lang::log;
 #[derive(clap::Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 pub struct Args {

--- a/mimium-cli/src/main.rs
+++ b/mimium-cli/src/main.rs
@@ -5,8 +5,10 @@ use std::path::{Path, PathBuf};
 use clap::{Parser, ValueEnum};
 use mimium_audiodriver::backends::csv::{csv_driver, csv_driver_stdout};
 use mimium_audiodriver::driver::{load_default_runtime, SampleRate};
+use mimium_guitools::GuiToolPlugin;
 use mimium_lang::compiler::emit_ast;
 use mimium_lang::interner::{ExprNodeId, Symbol, ToSymbol};
+use mimium_lang::log;
 use mimium_lang::plugin::Plugin;
 use mimium_lang::utils::error::ReportableError;
 use mimium_lang::utils::miniprint::MiniPrint;
@@ -15,7 +17,6 @@ use mimium_lang::ExecContext;
 use mimium_lang::{compiler::mirgen::convert_pronoun, repl};
 use mimium_midi;
 use mimium_symphonia::{self, SamplerPlugin};
-use mimium_lang::log;
 #[derive(clap::Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 pub struct Args {
@@ -108,6 +109,9 @@ fn get_default_context(path: Option<Symbol>) -> ExecContext {
     let mut ctx = ExecContext::new(plugins.into_iter(), path);
     ctx.add_system_plugin(mimium_scheduler::get_default_scheduler_plugin());
     ctx.add_system_plugin(mimium_midi::MidiPlugin::default());
+    #[cfg(not(target_arch = "wasm32"))]
+    ctx.add_system_plugin(mimium_guitools::GuiToolPlugin::default());
+
     ctx
 }
 

--- a/mimium-cli/src/main.rs
+++ b/mimium-cli/src/main.rs
@@ -5,7 +5,6 @@ use std::path::{Path, PathBuf};
 use clap::{Parser, ValueEnum};
 use mimium_audiodriver::backends::csv::{csv_driver, csv_driver_stdout};
 use mimium_audiodriver::driver::{load_default_runtime, SampleRate};
-use mimium_guitools::GuiToolPlugin;
 use mimium_lang::compiler::emit_ast;
 use mimium_lang::interner::{ExprNodeId, Symbol, ToSymbol};
 use mimium_lang::log;
@@ -152,7 +151,7 @@ fn run_file(
         };
         let audiodriver_plug = driver.get_as_plugin();
         ctx.add_plugin(audiodriver_plug);
-        let _res = ctx.vm.as_mut().unwrap().execute_main();
+        let _res = ctx.run_main();
         let mainloop = ctx.try_get_main_loop().unwrap_or(Box::new(|| {
             //wait until input something
             let mut dummy = String::new();

--- a/mimium-cli/src/main.rs
+++ b/mimium-cli/src/main.rs
@@ -152,13 +152,16 @@ fn run_file(
         };
         let audiodriver_plug = driver.get_as_plugin();
         ctx.add_plugin(audiodriver_plug);
+        let _res = ctx.vm.as_mut().unwrap().execute_main();
+        let mainloop = ctx.try_get_main_loop().unwrap_or(Box::new(|| {
+            //wait until input something
+            let mut dummy = String::new();
+            eprintln!("Press Enter to exit");
+            let _size = stdin().read_line(&mut dummy).expect("stdin read error.");
+        }));
         driver.init(ctx, Some(SampleRate(48000)));
         driver.play();
-
-        //wait until input something
-        let mut dummy = String::new();
-        eprintln!("Press Enter to exit");
-        let _size = stdin().read_line(&mut dummy).expect("stdin read error.");
+        mainloop()
     }
 
     Ok(())

--- a/mimium-guitools/Cargo.toml
+++ b/mimium-guitools/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "mimium-guitools"
+version = "2.0.0-alpha-1"
+license = "MPL 2.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+# [lib]
+
+
+[dependencies]
+egui = "0.29.1"
+egui_plot = "0.29.0"
+mimium-lang = {path = "../mimium-lang"}

--- a/mimium-guitools/Cargo.toml
+++ b/mimium-guitools/Cargo.toml
@@ -11,4 +11,10 @@ edition = "2021"
 [dependencies]
 egui = "0.29.1"
 egui_plot = "0.29.0"
-mimium-lang = {path = "../mimium-lang"}
+mimium-lang = { path = "../mimium-lang" }
+eframe = { version = "0.29.1", default-features = false, features = [
+    "default_fonts", # Embed the default egui fonts.
+    "glow",          # Use the glow rendering backend. Alternative: "wgpu".
+    "persistence",   # Enable restoring app state when restarting the app.
+] }
+ringbuf = "0.4.7"

--- a/mimium-guitools/examples/plot.mmm
+++ b/mimium-guitools/examples/plot.mmm
@@ -6,15 +6,19 @@ fn phasor(freq){
 fn osc(freq){
   sin(phasor(freq)*pi*2.0)
 }
-fn amosc(freq,rate){
+fn fmosc(freq,rate){
   osc(freq + osc(rate)*4000.0)
 }
+fn amosc(input,rate){
+   input * (osc(rate)+1.0/ 2)
+}
+
 
 let probel = make_probe("left")
 let prober = make_probe("right")
 
 fn dsp(){
-    let l = probel(amosc(880,0.5))
-    let r = prober(amosc(660,0.3))
+    let l = probel(amosc(fmosc(440,0.02) , 0.2))
+    let r = prober(amosc(fmosc(220,0.03) , 0.3))
     (l,r)
 }

--- a/mimium-guitools/examples/plot.mmm
+++ b/mimium-guitools/examples/plot.mmm
@@ -1,0 +1,20 @@
+let pi = 3.14159265359
+let sr = 48000.0
+fn phasor(freq){
+  (self + freq/sr)%1.0
+}
+fn osc(freq){
+  sin(phasor(freq)*pi*2.0)
+}
+fn amosc(freq,rate){
+  osc(freq + osc(rate)*4000.0)
+}
+
+let probel = make_probe("left")
+let prober = make_probe("right")
+
+fn dsp(){
+    let l = probel(amosc(880,0.5))
+    let r = prober(amosc(660,0.3))
+    (l,r)
+}

--- a/mimium-guitools/examples/plot_and_midi.mmm
+++ b/mimium-guitools/examples/plot_and_midi.mmm
@@ -51,11 +51,9 @@ fn synth(midiv){
     sig *  gain
 }
 
-let ch0  = bind_midi_note_mono( 0.0,69.0,0.0);
+let ch0  = bind_midi_note_mono(0.0,69.0,0.0);
 
 let probe = make_probe("sig")
-
-
 fn dsp(){
     let l = probe(ch0() |> synth)
     (l,l)

--- a/mimium-guitools/examples/plot_and_midi.mmm
+++ b/mimium-guitools/examples/plot_and_midi.mmm
@@ -1,0 +1,63 @@
+let pi = 3.14159265359
+let sr = 48000.0
+fn sec2samp(sec){
+    sec*48000.0
+}
+fn countup(active){
+    let r  =(self+1.0);
+    let rr = if (active) r else 0.0
+    rr
+}
+fn countupn(time,active){
+    let res = countup(active)
+    let r = if(res<time) res else 0.0
+    r
+}
+fn hold(time,active){
+    countupn(time,active)>0.0
+}
+fn get_gain(gate){
+    if (gate>0.1) gate else self
+}
+fn adsr(attack,decay,sustain,release,input){
+    let s = self
+    let atsig = min(1.0,(s + 1.0/sec2samp(attack)))
+    let decsig = max(sustain,(s-1.0/sec2samp(decay)))
+    let releasesig =max(0.0,(s-1.0/sec2samp(release)))
+    let at_or_dec = hold(sec2samp(attack),input>0.1)
+    let at_dec_sus_sig = if (at_or_dec>0.1) atsig else decsig
+    let res = if (input>0.1) at_dec_sus_sig else releasesig
+    res
+}
+
+fn phasor(freq){
+  (self + freq/sr)%1.0
+}
+fn osc(freq){
+  sin(phasor(freq)*pi*2.0)
+}
+
+fn midi_to_hz(note){
+    440.0*  (2.0 ^((note-69.0)/12.0))
+}
+fn myadsr(gate){
+    adsr(0.01,0.1,1.0,2.0,gate) *get_gain(gate)
+}
+fn synth(note,vel){
+    let sig = note |> midi_to_hz |> osc 
+    let gain = vel /127.0;
+    sig *  gain
+}
+
+let ch0  = bind_midi_note_mono( 0.0,69.0,0.0);
+
+let probe = make_probe("sig")
+let probem = make_probe("midi")
+
+
+fn dsp(){
+    let (note,vel) = ch0()
+    let vel = probem(vel)
+    let l = probe(synth(note,vel))
+    (l,l)
+}

--- a/mimium-guitools/examples/plot_and_midi.mmm
+++ b/mimium-guitools/examples/plot_and_midi.mmm
@@ -1,5 +1,6 @@
 let pi = 3.14159265359
 let sr = 48000.0
+let _ = set_midi_port("from Max 1")
 fn sec2samp(sec){
     sec*48000.0
 }
@@ -43,7 +44,8 @@ fn midi_to_hz(note){
 fn myadsr(gate){
     adsr(0.01,0.1,1.0,2.0,gate) *get_gain(gate)
 }
-fn synth(note,vel){
+fn synth(midiv){
+    let (note,vel) = midiv
     let sig = note |> midi_to_hz |> osc 
     let gain = vel /127.0;
     sig *  gain
@@ -52,12 +54,9 @@ fn synth(note,vel){
 let ch0  = bind_midi_note_mono( 0.0,69.0,0.0);
 
 let probe = make_probe("sig")
-let probem = make_probe("midi")
 
 
 fn dsp(){
-    let (note,vel) = ch0()
-    let vel = probem(vel)
-    let l = probe(synth(note,vel))
+    let l = probe(ch0() |> synth)
     (l,l)
 }

--- a/mimium-guitools/readme.md
+++ b/mimium-guitools/readme.md
@@ -1,0 +1,19 @@
+# mimium-guitools
+
+This plugin provides various ways to interact gui through `egui` crate. Works only on native architecture.
+
+## Plot signals
+
+```rust
+fn osc(freq){
+    ...
+}
+let probe1 = make_probe("probe_label1")//when more than 1 probes are created, gui window will be launched on the startup.
+
+fn dsp(){
+    let r = probe1(osc(440)) // probe closure returns original value.
+    (r,r)
+}
+
+```
+

--- a/mimium-guitools/src/lib.rs
+++ b/mimium-guitools/src/lib.rs
@@ -1,3 +1,5 @@
+
+
 use mimium_lang::{
     function,
     interner::ToSymbol,
@@ -12,7 +14,8 @@ use mimium_lang::{
 pub struct GuiToolPlugin{
 
 }
-
+pub(crate) mod plot_ui;
+pub mod plot_window;
 impl SystemPlugin for GuiToolPlugin{
     fn gen_interfaces(&self) -> Vec<SysPluginSignature> {
         todo!()

--- a/mimium-guitools/src/lib.rs
+++ b/mimium-guitools/src/lib.rs
@@ -3,7 +3,7 @@ use std::{cell::RefCell, rc::Rc};
 use mimium_lang::{
     function,
     interner::ToSymbol,
-    numeric,
+    log, numeric,
     plugin::{SysPluginSignature, SystemPlugin, SystemPluginFnType},
     runtime::vm::{ExtClsInfo, Machine, ReturnCode},
     string_t,
@@ -17,32 +17,52 @@ use ringbuf::{
 pub(crate) mod plot_ui;
 pub mod plot_window;
 pub struct GuiToolPlugin {
-    window: plot_window::PlotApp,
+    window: Option<plot_window::PlotApp>,
 }
 
 impl GuiToolPlugin {
     /// This method is exposed as "make_probe(label:String)->(float)->float".
     pub fn make_probe(&mut self, vm: &mut Machine) -> ReturnCode {
-        let idx = vm.get_stack(0);
-        let probename = vm.prog.strings[idx as usize].as_str();
+        if let Some(app) = &mut self.window {
+            log::warn!("make_probe called other than global context.");
+            let idx = vm.get_stack(0);
+            let probename = vm.prog.strings[idx as usize].as_str();
 
-        let fnty = function!(vec![numeric!()], numeric!());
-        let (mut prod, cons) = HeapRb::<f64>::new(512).split();
-        self.window.add_plot(probename, cons);
-        let cb = move |vm: &mut Machine| -> ReturnCode {
-            let v = Machine::get_as::<f64>(vm.get_stack(0));
-            let _ = prod.try_push(v);
-            //do not modify any stack values
-            1
-        };
-        let info: ExtClsInfo = ("probegetter".to_symbol(), Rc::new(RefCell::new(cb)), fnty);
-        let cls = vm.wrap_extern_cls(info);
-        vm.set_stack(0, Machine::to_value(cls));
+            let fnty = function!(vec![numeric!()], numeric!());
+            let (mut prod, cons) = HeapRb::<f64>::new(512).split();
+            app.add_plot(probename, cons);
+            let cb = move |vm: &mut Machine| -> ReturnCode {
+                let v = Machine::get_as::<f64>(vm.get_stack(0));
+                let _ = prod.try_push(v);
+                //do not modify any stack values
+                1
+            };
+            let info: ExtClsInfo = ("probegetter".to_symbol(), Rc::new(RefCell::new(cb)), fnty);
+            let cls = vm.wrap_extern_cls(info);
+            vm.set_stack(0, Machine::to_value(cls));
+        }
         1
     }
 }
 
 impl SystemPlugin for GuiToolPlugin {
+    fn after_main(&mut self, _machine: &mut Machine) -> ReturnCode {
+        let native_options = eframe::NativeOptions {
+            viewport: egui::ViewportBuilder::default()
+                .with_inner_size([400.0, 300.0])
+                .with_min_inner_size([300.0, 220.0]), // .with_icon(
+                                                      //     // NOTE: Adding an icon is optional
+                                                      //     eframe::icon_data::from_png_bytes(&include_bytes!("../assets/icon-256.png")[..])
+                                                      //         .expect("Failed to load icon"),)
+            ..Default::default()
+        };
+        let _ = eframe::run_native(
+            "mimium guitools",
+            native_options,
+            Box::new(|_cc| Ok(Box::new(self.window.take().unwrap()))),
+        );
+        0
+    }
     fn gen_interfaces(&self) -> Vec<SysPluginSignature> {
         let ty = function!(vec![string_t!()], unit!());
         let fptr: SystemPluginFnType<Self> = Self::make_probe;

--- a/mimium-guitools/src/lib.rs
+++ b/mimium-guitools/src/lib.rs
@@ -4,36 +4,38 @@ use mimium_lang::{
     function,
     interner::ToSymbol,
     numeric,
-    plugin::{SysPluginSignature, SystemPlugin},
-    runtime::vm::{self, ExtClsInfo, Machine, ReturnCode},
-    string_t, tuple,
+    plugin::{SysPluginSignature, SystemPlugin, SystemPluginFnType},
+    runtime::vm::{ExtClsInfo, Machine, ReturnCode},
+    string_t,
     types::{PType, Type},
     unit,
 };
-use ringbuf::{traits::{Producer, Split}, HeapRb};
+use ringbuf::{
+    traits::{Producer, Split},
+    HeapRb,
+};
 pub(crate) mod plot_ui;
 pub mod plot_window;
 pub struct GuiToolPlugin {
     window: plot_window::PlotApp,
 }
 
-impl GuiToolPlugin{
-
-
-    pub fn make_probe(&mut self, vm:&mut Machine)->ReturnCode{
+impl GuiToolPlugin {
+    /// This method is exposed as "make_probe(label:String)->(float)->float".
+    pub fn make_probe(&mut self, vm: &mut Machine) -> ReturnCode {
         let idx = vm.get_stack(0);
         let probename = vm.prog.strings[idx as usize].as_str();
 
-        let fnty = function!(vec![numeric!()],numeric!());
-        let (mut prod,cons)= HeapRb::<f64>::new(512).split();
+        let fnty = function!(vec![numeric!()], numeric!());
+        let (mut prod, cons) = HeapRb::<f64>::new(512).split();
         self.window.add_plot(probename, cons);
-        let cb = move|vm:&mut Machine|->ReturnCode{
+        let cb = move |vm: &mut Machine| -> ReturnCode {
             let v = Machine::get_as::<f64>(vm.get_stack(0));
             let _ = prod.try_push(v);
             //do not modify any stack values
-            1  
+            1
         };
-        let info:ExtClsInfo = ("probegetter".to_symbol(),Rc::new(RefCell::new(cb)),fnty);
+        let info: ExtClsInfo = ("probegetter".to_symbol(), Rc::new(RefCell::new(cb)), fnty);
         let cls = vm.wrap_extern_cls(info);
         vm.set_stack(0, Machine::to_value(cls));
         1
@@ -42,6 +44,9 @@ impl GuiToolPlugin{
 
 impl SystemPlugin for GuiToolPlugin {
     fn gen_interfaces(&self) -> Vec<SysPluginSignature> {
-        todo!()
+        let ty = function!(vec![string_t!()], unit!());
+        let fptr: SystemPluginFnType<Self> = Self::make_probe;
+        let make_probe = SysPluginSignature::new("make_probe", fptr, ty);
+        vec![make_probe]
     }
 }

--- a/mimium-guitools/src/lib.rs
+++ b/mimium-guitools/src/lib.rs
@@ -1,22 +1,46 @@
-
+use std::{cell::RefCell, rc::Rc};
 
 use mimium_lang::{
     function,
     interner::ToSymbol,
     numeric,
     plugin::{SysPluginSignature, SystemPlugin},
-    runtime::vm,
+    runtime::vm::{self, ExtClsInfo, Machine, ReturnCode},
     string_t, tuple,
     types::{PType, Type},
     unit,
 };
-
-pub struct GuiToolPlugin{
-
-}
+use ringbuf::{traits::{Producer, Split}, HeapRb};
 pub(crate) mod plot_ui;
 pub mod plot_window;
-impl SystemPlugin for GuiToolPlugin{
+pub struct GuiToolPlugin {
+    window: plot_window::PlotApp,
+}
+
+impl GuiToolPlugin{
+
+
+    pub fn make_probe(&mut self, vm:&mut Machine)->ReturnCode{
+        let idx = vm.get_stack(0);
+        let probename = vm.prog.strings[idx as usize].as_str();
+
+        let fnty = function!(vec![numeric!()],numeric!());
+        let (mut prod,cons)= HeapRb::<f64>::new(512).split();
+        self.window.add_plot(probename, cons);
+        let cb = move|vm:&mut Machine|->ReturnCode{
+            let v = Machine::get_as::<f64>(vm.get_stack(0));
+            let _ = prod.try_push(v);
+            //do not modify any stack values
+            1  
+        };
+        let info:ExtClsInfo = ("probegetter".to_symbol(),Rc::new(RefCell::new(cb)),fnty);
+        let cls = vm.wrap_extern_cls(info);
+        vm.set_stack(0, Machine::to_value(cls));
+        1
+    }
+}
+
+impl SystemPlugin for GuiToolPlugin {
     fn gen_interfaces(&self) -> Vec<SysPluginSignature> {
         todo!()
     }

--- a/mimium-guitools/src/lib.rs
+++ b/mimium-guitools/src/lib.rs
@@ -1,0 +1,20 @@
+use mimium_lang::{
+    function,
+    interner::ToSymbol,
+    numeric,
+    plugin::{SysPluginSignature, SystemPlugin},
+    runtime::vm,
+    string_t, tuple,
+    types::{PType, Type},
+    unit,
+};
+
+pub struct GuiToolPlugin{
+
+}
+
+impl SystemPlugin for GuiToolPlugin{
+    fn gen_interfaces(&self) -> Vec<SysPluginSignature> {
+        todo!()
+    }
+}

--- a/mimium-guitools/src/main.rs
+++ b/mimium-guitools/src/main.rs
@@ -1,0 +1,26 @@
+/// Standalone app for testing.
+/// 
+use mimium_guitools::plot_window::PlotApp;
+
+// When compiling natively:
+#[cfg(not(target_arch = "wasm32"))]
+fn main() -> eframe::Result {
+    // env_logger::init(); // Log to stderr (if you run with `RUST_LOG=debug`).
+
+    let native_options = eframe::NativeOptions {
+        viewport: egui::ViewportBuilder::default()
+            .with_inner_size([400.0, 300.0])
+            .with_min_inner_size([300.0, 220.0])
+            // .with_icon(
+            //     // NOTE: Adding an icon is optional
+            //     eframe::icon_data::from_png_bytes(&include_bytes!("../assets/icon-256.png")[..])
+            //         .expect("Failed to load icon"),)
+            ,
+        ..Default::default()
+    };
+    eframe::run_native(
+        "eframe template",
+        native_options,
+        Box::new(|cc| Ok(Box::new(PlotApp::new_test()))),
+    )
+}

--- a/mimium-guitools/src/main.rs
+++ b/mimium-guitools/src/main.rs
@@ -19,8 +19,8 @@ fn main() -> eframe::Result {
         ..Default::default()
     };
     eframe::run_native(
-        "eframe template",
+        "mimium guitools",
         native_options,
-        Box::new(|cc| Ok(Box::new(PlotApp::new_test()))),
+        Box::new(|_cc| Ok(Box::new(PlotApp::new_test()))),
     )
 }

--- a/mimium-guitools/src/plot_ui.rs
+++ b/mimium-guitools/src/plot_ui.rs
@@ -1,0 +1,61 @@
+use egui::Color32;
+use egui_plot::{CoordinatesFormatter, Corner, Legend, Line, LineStyle, Plot, PlotPoints};
+use ringbuf::{traits::Consumer, HeapCons, HeapRb};
+pub(crate) struct PlotUi {
+    label: String,
+    show_axes: bool,
+    show_grid: bool,
+    buf: HeapCons<f64>,
+    local_buf: Vec<f64>,
+}
+impl PlotUi {
+    pub fn new(label: &str, buf: HeapCons<f64>) -> Self {
+        let local_buf = (0..512)
+            .into_iter()
+            .map(|t| (6.28 * (t as f64 / 512.0)).sin())
+            .collect();
+        Self {
+            label:label.to_string(),
+            show_axes: true,
+            show_grid: true,
+            buf,
+            local_buf,
+        }
+    }
+    pub fn new_test(label: &str) -> Self {
+        let local_buf = (0..512)
+            .into_iter()
+            .map(|t| (6.28 * (t as f64 / 512.0)).sin())
+            .collect();
+        Self {
+            label:label.to_string(),
+            show_axes: true,
+            show_grid: true,
+            buf: HeapCons::new(HeapRb::new(10).into()),
+            local_buf,
+        }
+    }
+    fn draw_line(&self) -> Line {
+        Line::new(PlotPoints::from_parametric_callback(
+            |t| (t, self.local_buf[t as usize]),
+            0.0..512.0,
+            512,
+        ))
+        .color(Color32::from_rgb(200, 100, 100))
+        .style(LineStyle::Solid)
+        .name(&self.label)
+    }
+}
+impl egui::Widget for &mut PlotUi {
+    fn ui(self, ui: &mut egui::Ui) -> egui::Response {
+        let plot = Plot::new("lines_demo")
+            .legend(Legend::default())
+            .show_axes(self.show_axes)
+            .show_grid(self.show_grid)
+            .coordinates_formatter(Corner::LeftBottom, CoordinatesFormatter::default());
+        plot.show(ui, |plot_ui| {
+            plot_ui.line(self.draw_line());
+        })
+        .response
+    }
+}

--- a/mimium-guitools/src/plot_ui.rs
+++ b/mimium-guitools/src/plot_ui.rs
@@ -7,6 +7,7 @@ pub(crate) struct PlotUi {
     show_grid: bool,
     buf: HeapCons<f64>,
     local_buf: Vec<f64>,
+    update_index:usize,
 }
 impl PlotUi {
     pub fn new(label: &str, buf: HeapCons<f64>) -> Self {
@@ -20,6 +21,7 @@ impl PlotUi {
             show_grid: true,
             buf,
             local_buf,
+            update_index:0
         }
     }
     pub fn new_test(label: &str) -> Self {
@@ -33,9 +35,15 @@ impl PlotUi {
             show_grid: true,
             buf: HeapCons::new(HeapRb::new(10).into()),
             local_buf,
+            update_index:0
         }
     }
-    fn draw_line(&self) -> Line {
+    fn draw_line(&mut self) -> Line {
+        while let Some(s) = self.buf.try_pop(){
+            self.local_buf[self.update_index] = s;
+            self.update_index= (self.update_index+1)%self.local_buf.len();
+        }
+
         Line::new(PlotPoints::from_parametric_callback(
             |t| (t, self.local_buf[t as usize]),
             0.0..512.0,

--- a/mimium-guitools/src/plot_ui.rs
+++ b/mimium-guitools/src/plot_ui.rs
@@ -1,69 +1,55 @@
-use egui::Color32;
+use egui::{Color32, Stroke};
 use egui_plot::{CoordinatesFormatter, Corner, Legend, Line, LineStyle, Plot, PlotPoints};
 use ringbuf::{traits::Consumer, HeapCons, HeapRb};
 pub(crate) struct PlotUi {
     label: String,
-    show_axes: bool,
-    show_grid: bool,
+    color: Color32,
     buf: HeapCons<f64>,
     local_buf: Vec<f64>,
-    update_index:usize,
+    update_index: usize,
 }
 impl PlotUi {
-    pub fn new(label: &str, buf: HeapCons<f64>) -> Self {
-        let local_buf = (0..512)
-            .into_iter()
-            .map(|_| 0.0)
-            .collect();
+    pub fn new(label: &str, buf: HeapCons<f64>, color: Color32) -> Self {
+        let local_buf = (0..4096).into_iter().map(|_| 0.0).collect();
+
         Self {
-            label:label.to_string(),
-            show_axes: true,
-            show_grid: true,
+            label: label.to_string(),
+            color,
             buf,
             local_buf,
-            update_index:0
+            update_index: 0,
         }
     }
     pub fn new_test(label: &str) -> Self {
-        let local_buf = (0..512)
+        let local_buf = (0..4096)
             .into_iter()
-            .map(|t| (6.28 * (t as f64 / 512.0)).sin())
+            .map(|t| (6.28 * (t as f64 / 4096.0)).sin())
             .collect();
         Self {
-            label:label.to_string(),
-            show_axes: true,
-            show_grid: true,
+            label: label.to_string(),
+            color: Color32::from_rgb(255, 0, 0),
             buf: HeapCons::new(HeapRb::new(10).into()),
             local_buf,
-            update_index:0
+            update_index: 0,
         }
     }
-    fn draw_line(&mut self) -> Line {
-        while let Some(s) = self.buf.try_pop(){
+    pub(crate) fn draw_line(&mut self) -> (bool, Line) {
+        let mut request_repaint = false;
+        while let Some(s) = self.buf.try_pop() {
+            request_repaint = true;
             self.local_buf[self.update_index] = s;
-            self.update_index= (self.update_index+1)%self.local_buf.len();
+            self.update_index = (self.update_index + 1) % self.local_buf.len();
         }
 
-        Line::new(PlotPoints::from_parametric_callback(
+        let line = Line::new(PlotPoints::from_parametric_callback(
             |t| (t, self.local_buf[t as usize]),
-            0.0..512.0,
-            512,
+            0.0..4096.0,
+            4096,
         ))
-        .color(Color32::from_rgb(200, 100, 100))
+        // .color(...)
+        .color(self.color)
         .style(LineStyle::Solid)
-        .name(&self.label)
-    }
-}
-impl egui::Widget for &mut PlotUi {
-    fn ui(self, ui: &mut egui::Ui) -> egui::Response {
-        let plot = Plot::new("lines_demo")
-            .legend(Legend::default())
-            .show_axes(self.show_axes)
-            .show_grid(self.show_grid)
-            .coordinates_formatter(Corner::LeftBottom, CoordinatesFormatter::default());
-        plot.show(ui, |plot_ui| {
-            plot_ui.line(self.draw_line());
-        })
-        .response
+        .name(&self.label);
+        (request_repaint, line)
     }
 }

--- a/mimium-guitools/src/plot_ui.rs
+++ b/mimium-guitools/src/plot_ui.rs
@@ -13,7 +13,7 @@ impl PlotUi {
     pub fn new(label: &str, buf: HeapCons<f64>) -> Self {
         let local_buf = (0..512)
             .into_iter()
-            .map(|t| (6.28 * (t as f64 / 512.0)).sin())
+            .map(|_| 0.0)
             .collect();
         Self {
             label:label.to_string(),

--- a/mimium-guitools/src/plot_ui.rs
+++ b/mimium-guitools/src/plot_ui.rs
@@ -1,5 +1,5 @@
-use egui::{Color32, Stroke};
-use egui_plot::{CoordinatesFormatter, Corner, Legend, Line, LineStyle, Plot, PlotPoints};
+use egui::Color32;
+use egui_plot::{Line, LineStyle, PlotPoints};
 use ringbuf::{traits::Consumer, HeapCons, HeapRb};
 pub(crate) struct PlotUi {
     label: String,

--- a/mimium-guitools/src/plot_window.rs
+++ b/mimium-guitools/src/plot_window.rs
@@ -1,10 +1,10 @@
 use crate::plot_ui::{self, PlotUi};
 use eframe;
-use egui::{Response, Widget};
-use egui_plot::PlotResponse;
-use mimium_lang::plugin::Plugin;
-use ringbuf::{Cons, HeapCons};
+use egui::Widget;
 
+use ringbuf::HeapCons;
+
+#[derive(Default)]
 pub struct PlotApp {
     plot: Vec<plot_ui::PlotUi>,
 }

--- a/mimium-guitools/src/plot_window.rs
+++ b/mimium-guitools/src/plot_window.rs
@@ -1,0 +1,48 @@
+use crate::plot_ui::{self, PlotUi};
+use eframe;
+use egui::{Response, Widget};
+use egui_plot::PlotResponse;
+use mimium_lang::plugin::Plugin;
+use ringbuf::{Cons, HeapCons};
+
+pub struct PlotApp {
+    plot: Vec<plot_ui::PlotUi>,
+}
+
+impl PlotApp {
+    pub fn new_test() -> Self {
+        let plot = vec![PlotUi::new_test("test")];
+        Self { plot }
+    }
+    pub fn add_plot(&mut self, label: &str, buf: HeapCons<f64>) {
+        self.plot.push(PlotUi::new(label, buf))
+    }
+}
+
+impl eframe::App for PlotApp {
+    fn update(&mut self, ctx: &egui::Context, frame: &mut eframe::Frame) {
+        egui::TopBottomPanel::top("top_panel").show(ctx, |ui| {
+            // The top panel is often a good place for a menu bar:
+
+            egui::menu::bar(ui, |ui| {
+                egui::widgets::global_theme_preference_buttons(ui);
+                ui.add_space(16.0);
+                use egui::special_emojis::GITHUB;
+                ui.hyperlink_to(
+                    format!("{GITHUB} mimium-rs on GitHub"),
+                    "https://github.com/tomoyanonymous/mimium-rs",
+                );
+            });
+        });
+
+        egui::CentralPanel::default().show(ctx, |ui| {
+            ui.horizontal_centered(|ui| {
+                for plot in self.plot.iter_mut() {
+                    ui.vertical_centered_justified(|ui| {
+                        plot.ui(ui);
+                    });
+                }
+            })
+        });
+    }
+}

--- a/mimium-guitools/src/plot_window.rs
+++ b/mimium-guitools/src/plot_window.rs
@@ -9,12 +9,17 @@ use ringbuf::HeapCons;
 pub struct PlotApp {
     plot: Vec<plot_ui::PlotUi>,
     hue: f32,
+    autoscale: bool,
 }
 
 impl PlotApp {
     pub fn new_test() -> Self {
         let plot = vec![PlotUi::new_test("test")];
-        Self { plot, hue: 0.0 }
+        Self {
+            plot,
+            hue: 0.0,
+            autoscale: false,
+        }
     }
     const HUE_MARGIN: f32 = 1.0 / 8.0 + 0.3;
     pub fn add_plot(&mut self, label: &str, buf: HeapCons<f64>) {
@@ -41,6 +46,7 @@ impl eframe::App for PlotApp {
                     format!("{GITHUB} mimium-rs on GitHub"),
                     "https://github.com/tomoyanonymous/mimium-rs",
                 );
+                ui.checkbox(&mut self.autoscale, "Auto Scale")
             });
         });
 
@@ -49,6 +55,7 @@ impl eframe::App for PlotApp {
                 .legend(Legend::default())
                 .show_axes(true)
                 .show_grid(true)
+                .auto_bounds([true,self.autoscale].into())
                 .coordinates_formatter(Corner::LeftBottom, CoordinatesFormatter::default());
 
             plot.show(ui, |plot_ui| {

--- a/mimium-lang/src/lib.rs
+++ b/mimium-lang/src/lib.rs
@@ -25,6 +25,7 @@ use runtime::vm::{
     ExtClsInfo, Program,
 };
 use utils::error::ReportableError;
+pub use log;
 
 /// A set of compiler and external functions (plugins).
 /// From this information, user can generate VM with [`Self::prepare_machine`].

--- a/mimium-lang/src/plugin.rs
+++ b/mimium-lang/src/plugin.rs
@@ -8,7 +8,7 @@
 //! 3. **System Plugin**. If your plugin needs to mutate states of system-wide instance (1 plugin instance per 1 vm), you need to implement `SystemPlugin` traits. System plugin can have callbacks invoked at the important timings of the system like `on_init`, `before_on_sample` & so on. Internal synchronous event scheduler is implemented through this plugins system. `mimium-rand` is also an example of this type of module.
 
 mod system_plugin;
-pub use system_plugin::{to_ext_cls_info, DynSystemPlugin, SysPluginSignature, SystemPlugin};
+pub use system_plugin::{to_ext_cls_info, DynSystemPlugin, SysPluginSignature, SystemPlugin,SystemPluginFnType};
 
 use crate::{
     compiler::ExtFunTypeInfo,

--- a/mimium-lang/src/plugin/system_plugin.rs
+++ b/mimium-lang/src/plugin/system_plugin.rs
@@ -33,19 +33,23 @@ impl SysPluginSignature {
 }
 
 pub trait SystemPlugin {
-    fn on_init(&mut self, _machine: &mut Machine) -> ReturnCode{
+    fn on_init(&mut self, _machine: &mut Machine) -> ReturnCode {
         0
     }
-    fn after_main(&mut self, _machine: &mut Machine) -> ReturnCode{
+    fn after_main(&mut self, _machine: &mut Machine) -> ReturnCode {
         0
     }
-    fn on_sample(&mut self, _time: Time, _machine: &mut Machine) -> ReturnCode{
+    fn on_sample(&mut self, _time: Time, _machine: &mut Machine) -> ReturnCode {
         0
     }
     fn gen_interfaces(&self) -> Vec<SysPluginSignature>;
+    fn try_get_main_loop(&mut self) -> Option<Box<dyn FnOnce()>> {
+        None
+    }
 }
 #[derive(Clone)]
 pub struct DynSystemPlugin(pub Rc<UnsafeCell<dyn SystemPlugin>>);
+
 
 pub fn to_ext_cls_info<T: SystemPlugin + 'static>(
     sysplugin: T,
@@ -61,7 +65,7 @@ pub fn to_ext_cls_info<T: SystemPlugin + 'static>(
                 .downcast::<fn(&mut T, &mut Machine) -> ReturnCode>()
                 .expect("invalid conversion applied in the system plugin resolution.");
             let fun = Rc::new(RefCell::new(move |machine: &mut Machine| -> ReturnCode {
-                // breaking double borrow rule at here!!! 
+                // breaking double borrow rule at here!!!
                 // Also here I do dirty downcasting because here the type of plugin is ensured as T.
                 unsafe {
                     let p = (plug.0.get() as *mut T).as_mut().unwrap();

--- a/mimium-lang/src/plugin/system_plugin.rs
+++ b/mimium-lang/src/plugin/system_plugin.rs
@@ -10,7 +10,7 @@ use std::{
     cell::{RefCell, UnsafeCell},
     rc::Rc,
 };
-
+pub type SystemPluginFnType<T> = fn(&mut T, &mut Machine) -> ReturnCode;
 pub struct SysPluginSignature {
     name: &'static str,
     /// The function internally implements Fn(&mut T:SystemPlugin,&mut Machine)->ReturnCode

--- a/mimium-lang/src/runtime/vm.rs
+++ b/mimium-lang/src/runtime/vm.rs
@@ -21,7 +21,7 @@ pub type RawVal = u64;
 pub type ReturnCode = i64;
 
 pub type ExtFunType = fn(&mut Machine) -> ReturnCode;
-pub type ExtClsType = Rc<RefCell<dyn Fn(&mut Machine) -> ReturnCode>>;
+pub type ExtClsType = Rc<RefCell<dyn FnMut(&mut Machine) -> ReturnCode>>;
 pub type ExtFnInfo = (Symbol, ExtFunType, TypeNodeId);
 pub type ExtClsInfo = (Symbol, ExtClsType, TypeNodeId);
 
@@ -680,7 +680,7 @@ impl Machine {
                             let (_name, cls) = &self.ext_cls_table[*ci];
                             let cls = cls.clone();
                             self.call_function(func, nargs, nret_req, move |machine| {
-                                cls.borrow()(machine)
+                                cls.borrow_mut()(machine)
                             })
                         }
                     };

--- a/mimium-midi/Cargo.toml
+++ b/mimium-midi/Cargo.toml
@@ -11,7 +11,6 @@ build = "build.rs"
 
 [dependencies]
 atomic_float = "1.1.0"
-log = "0.4.22"
 midir = "0.10.0"
 
 mimium-lang = { path = "../mimium-lang" }

--- a/mimium-midi/examples/midiin.mmm
+++ b/mimium-midi/examples/midiin.mmm
@@ -58,7 +58,6 @@ let ch15 = bind_midi_note_mono(15.0,69.0,0.0);
 
 fn myadsr(gate){
     adsr(0.01,0.1,1.0,2.0,gate) *get_gain(gate)
-
 }
 fn synth(midiv){
     let (note,vel) = midiv

--- a/mimium-midi/src/lib.rs
+++ b/mimium-midi/src/lib.rs
@@ -10,7 +10,7 @@ use mimium_lang::{
     interner::ToSymbol,
     numeric,
     plugin::{SysPluginSignature, SystemPlugin},
-    runtime::{vm, Time},
+    runtime::vm,
     string_t, tuple,
     types::{PType, Type},
     unit,

--- a/mimium-midi/src/lib.rs
+++ b/mimium-midi/src/lib.rs
@@ -14,6 +14,7 @@ use mimium_lang::{
     string_t, tuple,
     types::{PType, Type},
     unit,
+    log
 };
 use std::{
     cell::{OnceCell, RefCell},

--- a/mimium-midi/src/lib.rs
+++ b/mimium-midi/src/lib.rs
@@ -9,7 +9,7 @@ use mimium_lang::{
     function,
     interner::ToSymbol,
     numeric,
-    plugin::{SysPluginSignature, SystemPlugin},
+    plugin::{SysPluginSignature, SystemPlugin, SystemPluginFnType},
     runtime::vm,
     string_t, tuple,
     types::{PType, Type},
@@ -177,11 +177,10 @@ impl SystemPlugin for MidiPlugin {
             vec![numeric!(), numeric!(), numeric!()],
             function!(vec![], tuple!(numeric!(), numeric!()))
         );
-        let fun: fn(&mut Self, &mut vm::Machine) -> vm::ReturnCode = Self::bind_midi_note_mono;
+        let fun: SystemPluginFnType<Self> = Self::bind_midi_note_mono;
         let bindnote = SysPluginSignature::new("bind_midi_note_mono", fun, ty);
         let ty = function!(vec![string_t!()], unit!());
-        let fun: fn(&mut Self, &mut vm::Machine) -> vm::ReturnCode = Self::set_midi_port;
-
+        let fun: SystemPluginFnType<Self> = Self::set_midi_port;
         let setport = SysPluginSignature::new("set_midi_port", fun, ty);
         vec![setport, bindnote]
     }

--- a/mimium-symphonia/Cargo.toml
+++ b/mimium-symphonia/Cargo.toml
@@ -13,7 +13,6 @@ build = "build.rs"
 
 mimium-lang = { path = "../mimium-lang" }
 symphonia = "0.5.4"
-log = "0.4.22"
 
 [dev-dependencies]
 mimium-test = { path = "../mimium-test" }

--- a/mimium-test/Cargo.toml
+++ b/mimium-test/Cargo.toml
@@ -14,4 +14,3 @@ build = "build.rs"
 mimium-lang = { path = "../mimium-lang" }
 mimium-scheduler = {path = "../mimium-scheduler"}
 mimium-audiodriver = { path = "../mimium-audiodriver" }
-log = "0.4.22"


### PR DESCRIPTION
This PR adds new SystemPlugin: plotting signals with [egui-plot](https://github.com/emilk/egui_plot).

Because eframe(main application instance of egui) need to launch app in a main thread, this PR adds new API `try_get_main_loop` to `SystemPlugin`.
Multiple window can be realized with `egui`, however, root instance of the application is needed to spawn child windows.
Also, the global context evaluation is now done in `ExecContext::run_main`, not in `Driver::on_init` in order to resolve initialization order. Still, `LocalBufferDriver` does in `on_init`. There are code duplication remained now.
I may change structure of main app and system plugin later. 

<img width="1222" alt="スクリーンショット 2024-11-02 0 00 27" src="https://github.com/user-attachments/assets/07b79b3a-5829-4a34-bd57-f31f397dfae1">

