### PR TITLE
Fix clippy::redundant_static_lifetimes

### DIFF
--- a/mimium-lang/src/compiler/intrinsics.rs
+++ b/mimium-lang/src/compiler/intrinsics.rs
@@ -3,43 +3,43 @@ use std::cell::LazyCell;
 use crate::interner::{Symbol, ToSymbol};
 
 // unary
-pub(crate) const NEG: &'static str = "neg";
-pub(crate) const TOFLOAT: &'static str = "tofloat";
+pub(crate) const NEG: &str = "neg";
+pub(crate) const TOFLOAT: &str = "tofloat";
 
 // binary
-pub(crate) const ADD: &'static str = "add";
-pub(crate) const SUB: &'static str = "sub";
-pub(crate) const MULT: &'static str = "mult";
-pub(crate) const DIV: &'static str = "div";
-pub(crate) const EQ: &'static str = "eq";
-pub(crate) const NE: &'static str = "ne";
-pub(crate) const LE: &'static str = "le";
-pub(crate) const LT: &'static str = "lt";
-pub(crate) const GE: &'static str = "ge";
-pub(crate) const GT: &'static str = "gt";
-pub(crate) const MODULO: &'static str = "modulo";
-pub(crate) const POW: &'static str = "pow";
-pub(crate) const AND: &'static str = "and";
-pub(crate) const OR: &'static str = "or";
+pub(crate) const ADD: &str = "add";
+pub(crate) const SUB: &str = "sub";
+pub(crate) const MULT: &str = "mult";
+pub(crate) const DIV: &str = "div";
+pub(crate) const EQ: &str = "eq";
+pub(crate) const NE: &str = "ne";
+pub(crate) const LE: &str = "le";
+pub(crate) const LT: &str = "lt";
+pub(crate) const GE: &str = "ge";
+pub(crate) const GT: &str = "gt";
+pub(crate) const MODULO: &str = "modulo";
+pub(crate) const POW: &str = "pow";
+pub(crate) const AND: &str = "and";
+pub(crate) const OR: &str = "or";
 
 // arithmetics
-pub(crate) const SIN: &'static str = "sin";
-pub(crate) const COS: &'static str = "cos";
-pub(crate) const TAN: &'static str = "tan";
-pub(crate) const ATAN: &'static str = "atan";
-pub(crate) const ATAN2: &'static str = "atan2";
-pub(crate) const SQRT: &'static str = "sqrt";
-pub(crate) const ABS: &'static str = "abs";
-pub(crate) const LOG: &'static str = "log";
-pub(crate) const MIN: &'static str = "min";
-pub(crate) const MAX: &'static str = "max";
-pub(crate) const CEIL: &'static str = "ceil";
-pub(crate) const FLOOR: &'static str = "floor";
-pub(crate) const ROUND: &'static str = "round";
+pub(crate) const SIN: &str = "sin";
+pub(crate) const COS: &str = "cos";
+pub(crate) const TAN: &str = "tan";
+pub(crate) const ATAN: &str = "atan";
+pub(crate) const ATAN2: &str = "atan2";
+pub(crate) const SQRT: &str = "sqrt";
+pub(crate) const ABS: &str = "abs";
+pub(crate) const LOG: &str = "log";
+pub(crate) const MIN: &str = "min";
+pub(crate) const MAX: &str = "max";
+pub(crate) const CEIL: &str = "ceil";
+pub(crate) const FLOOR: &str = "floor";
+pub(crate) const ROUND: &str = "round";
 
 // other operations
-pub(crate) const DELAY: &'static str = "delay";
-pub(crate) const MEM: &'static str = "mem";
+pub(crate) const DELAY: &str = "delay";
+pub(crate) const MEM: &str = "mem";
 const BUILTIN_SYMS_UNSORTED: [&str; 31] = [
     NEG, TOFLOAT, ADD, SUB, MULT, DIV, EQ, NE, LE, LT, GE, GT, MODULO, POW, AND, OR, SIN, COS, TAN,
     ATAN, ATAN2, SQRT, ABS, LOG, MIN, MAX, CEIL, FLOOR, ROUND, DELAY, MEM,

--- a/mimium-lang/src/utils/metadata.rs
+++ b/mimium-lang/src/utils/metadata.rs
@@ -5,7 +5,7 @@ pub type Span = std::ops::Range<usize>;
 //     pub location: Span,
 //     pub value : T
 // }
-pub(crate) const GLOBAL_LABEL: &'static str = "_mimium_global";
+pub(crate) const GLOBAL_LABEL: &str = "_mimium_global";
 
 // #[derive(Clone, Debug, PartialEq)]
 // pub struct WithMeta<T: Clone + PartialEq>(pub T, pub Span);


### PR DESCRIPTION
This is a minor fix about https://rust-lang.github.io/rust-clippy/master/index.html#redundant_static_lifetimes.

``` sh
# suppress all lints and explicitly enable redundant_static_lifetimes lint
cargo +nightly clippy -- \
  -A dead_code -A unused_imports -A unused_variables -A clippy::all \
  -W clippy::redundant_static_lifetimes
```

```
warning: constants have by default a `'static` lifetime
 --> mimium-lang/src/utils/metadata.rs:8:33
  |
8 | pub(crate) const GLOBAL_LABEL: &'static str = "_mimium_global";
  |                                -^^^^^^^---- help: consider removing `'static`: `&str`
  |
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_static_lifetimes
  = note: requested on the command line with `-W clippy::redundant-static-lifetimes`
```