### PR TITLE
Remove or resolve some of my TODOs

### DIFF
--- a/mimium-lang/src/ast_interpreter.rs
+++ b/mimium-lang/src/ast_interpreter.rs
@@ -176,7 +176,7 @@ fn find_matched_builtin_fn(n: Symbol, tv: &[TypeNodeId]) -> Option<(Type, *const
         })
 }
 
-pub fn eval_extern(n: Symbol, argv: &Vec<Value>, span: Span) -> Result<Value, CompileError> {
+pub fn eval_extern(n: Symbol, argv: &[Value], span: Span) -> Result<Value, CompileError> {
     let tv = argv.iter().map(|v| v.get_type_id()).collect::<Vec<_>>();
 
     let (rt, ptr) = match find_matched_builtin_fn(n, &tv) {
@@ -185,7 +185,7 @@ pub fn eval_extern(n: Symbol, argv: &Vec<Value>, span: Span) -> Result<Value, Co
     };
     match argv.len() {
         1 => {
-            let v = argv.get(0).unwrap();
+            let v = &argv[0];
             match (rt, v) {
                 //f64 -> f64
                 (Type::Primitive(PType::Numeric), Value::Primitive(PValue::Numeric(fv)))
@@ -221,8 +221,8 @@ pub fn eval_extern(n: Symbol, argv: &Vec<Value>, span: Span) -> Result<Value, Co
             }
         }
         2 => {
-            let v1 = argv.get(0).unwrap();
-            let v2 = argv.get(1).unwrap();
+            let v1 = &argv[0];
+            let v2 = &argv[1];
             match (rt, v1, v2) {
                 // (f64,f64)->f64
                 (

--- a/mimium-lang/src/compiler/mirgen.rs
+++ b/mimium-lang/src/compiler/mirgen.rs
@@ -515,11 +515,6 @@ impl Context {
                 self.get_current_basicblock()
                     .0
                     .insert(alloc_insert_point, (dst.clone(), Instruction::Alloc(ty)));
-                // TODO: validate if the types are all identical?
-                // let first_ty = &types[0];
-                // if !types.iter().all(|x| x == first_ty) {
-                //     todo!("Return error");
-                // }
 
                 // pass only the head of the tuple, and the length can be known
                 // from the type information.

--- a/mimium-lang/src/compiler/parser/token.rs
+++ b/mimium-lang/src/compiler/parser/token.rs
@@ -114,7 +114,7 @@ impl Op {
             Op::Pipe => unreachable!(), // pipe is a syntax sugar, not a function
             Op::Unknown(x) => x.as_str(),
         }
-        .to_symbol() // TODO: use prefilled symbols instead of converting on the fly.
+        .to_symbol()
     }
 }
 

--- a/mimium-lang/src/runtime/builtin_fn.rs
+++ b/mimium-lang/src/runtime/builtin_fn.rs
@@ -226,7 +226,6 @@ macro_rules! f2_f {
     };
 }
 
-// TODO: use predefined symbols instead of strings
 pub fn get_builtin_fns() -> [BuiltinFn; 49] {
     [
         i_i!(neg),


### PR DESCRIPTION
I added several TODOs, but some of them are outdated and some are easy to resolve.

* `mimium-lang/src/ast_interpreter.rs`: `eval_extern()` is nested too deeply. I created a separate function.
* `mimium-lang/src/compiler/mirgen.rs`: This was simply my misunderstanding about `Tuple`. Just removed the TODO comment.
* `mimium-lang/src/compiler/parser/token.rs` & `mimium-lang/src/runtime/builtin_fn.rs`: As discussed in https://github.com/tomoyanonymous/mimium-rs/pull/31#issuecomment-2308142925, probably predefining symbols doesn't matter much. Just removed the TODO comments.
* `mimium-lang/src/types.rs`: Currently, `Type::apply_fn()` holds the actual logic, but it's used only via `TypeNodeId::apply_fn()`. So, I moved the code into `TypeNodeId` to reduce the round-trip conversions between these two types. Considering types are stored as `TypeNodeId` in most of the places, I guess this should cover most of the cases without`Type::apply_fn()` (and `Type::fold()` as well).