### PR TITLE
Allowing collecting multiple type check errors

### DIFF
--- a/mimium-audiodriver/src/driver.rs
+++ b/mimium-audiodriver/src/driver.rs
@@ -10,7 +10,6 @@ use mimium_lang::{
         vm::{self, ExtClsInfo, FuncProto, ReturnCode},
         Time,
     },
-    utils::error::ReportableError,
     ExecContext,
 };
 use num_traits::Float;
@@ -52,23 +51,7 @@ impl SampleRate {
         self.0.load(Ordering::Relaxed)
     }
 }
-#[derive(Debug)]
-pub enum Error {
-    Unknown,
-}
-impl std::fmt::Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Error::Unknown => write!(f, "unknown runtime error"),
-        }
-    }
-}
-impl std::error::Error for Error {}
-impl ReportableError for Error {
-    fn get_span(&self) -> std::ops::Range<usize> {
-        0..0 //todo!
-    }
-}
+
 
 /// Note: `Driver` trait doesn't have `new()` so that the struct can have its own
 /// `new()` with any parameters specific to the type. With this in mind, `init()`

--- a/mimium-cli/src/main.rs
+++ b/mimium-cli/src/main.rs
@@ -159,7 +159,7 @@ fn emit_ast_local(src: &str, filepath: &Path) -> Result<ExprNodeId, Vec<Box<dyn 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     if cfg!(debug_assertions) | cfg!(test) {
         colog::default_builder()
-            .filter_level(log::LevelFilter::Trace)
+            .filter_level(log::LevelFilter::Debug)
             .init();
     } else {
         colog::default_builder().init();

--- a/mimium-lang/benches/bench.rs
+++ b/mimium-lang/benches/bench.rs
@@ -156,7 +156,7 @@ fn dsp() {{
             let content = make_many_symbols_src(n);
             let compiler = compiler::Context::new([], None);
             b.iter(move || {
-                let (_mir, _errs) = compiler.emit_mir(&content);
+                let _mir = compiler.emit_mir(&content);
             });
         }
 

--- a/mimium-lang/benches/bench.rs
+++ b/mimium-lang/benches/bench.rs
@@ -59,19 +59,19 @@ fn dsp(){{
         }
         #[bench]
         fn bench_multiosc5(b: &mut Bencher) {
-            bench_runtime(b, &make_multiosc_src(5),1);
+            bench_runtime(b, &make_multiosc_src(5), 1);
         }
         #[bench]
         fn bench_multiosc7(b: &mut Bencher) {
-            bench_runtime(b, &make_multiosc_src(7),1);
+            bench_runtime(b, &make_multiosc_src(7), 1);
         }
         #[bench]
         fn bench_multiosc10(b: &mut Bencher) {
-            bench_runtime(b, &make_multiosc_src(9),1);
+            bench_runtime(b, &make_multiosc_src(9), 1);
         }
         #[bench]
         fn bench_multiosc15(b: &mut Bencher) {
-            bench_runtime(b, &make_multiosc_src(15),1);
+            bench_runtime(b, &make_multiosc_src(15), 1);
         }
         fn make_partialapp_src_from_template(c: &str) -> String {
             format!(
@@ -97,11 +97,11 @@ fn dsp(){{
         //test the performance degradation when open closure is made on `dsp` function with partial application.
         #[bench]
         fn bench_partialapp(b: &mut Bencher) {
-            bench_runtime(b, &make_partialapp_src(),10);
+            bench_runtime(b, &make_partialapp_src(), 10);
         }
         #[bench]
         fn bench_partialapp_no(b: &mut Bencher) {
-            bench_runtime(b, &make_no_partialapp_src(),10);
+            bench_runtime(b, &make_no_partialapp_src(), 10);
         }
     }
     mod parse {
@@ -154,8 +154,10 @@ fn dsp() {{
 
         fn bench_many_symbols(b: &mut Bencher, n: usize) {
             let content = make_many_symbols_src(n);
-            let compiler = compiler::Context::new([].into_iter(), None);
-            b.iter(move || compiler.emit_mir(&content).expect("ok"));
+            let compiler = compiler::Context::new([], None);
+            b.iter(move || {
+                let (_mir, _errs) = compiler.emit_mir(&content);
+            });
         }
 
         #[bench]

--- a/mimium-lang/src/ast.rs
+++ b/mimium-lang/src/ast.rs
@@ -2,7 +2,7 @@ pub mod builder;
 
 use crate::interner::{with_session_globals, ExprNodeId, Symbol, TypeNodeId};
 use crate::pattern::{TypedId, TypedPattern};
-use crate::utils::metadata::Span;
+use crate::utils::metadata::Location;
 use crate::utils::miniprint::MiniPrint;
 use std::fmt::{self};
 pub type Time = i64;
@@ -19,13 +19,13 @@ pub enum Literal {
 }
 
 impl Expr {
-    fn into_id_inner(self, span: Option<Span>) -> ExprNodeId {
-        let span = span.unwrap_or(0..0);
-        with_session_globals(|session_globals| session_globals.store_expr_with_span(self, span))
+    fn into_id_inner(self, loc: Option<Location>) -> ExprNodeId {
+        let loc = loc.unwrap_or_default();
+        with_session_globals(|session_globals| session_globals.store_expr_with_location(self, loc))
     }
 
-    pub fn into_id(self, span: Span) -> ExprNodeId {
-        self.into_id_inner(Some(span))
+    pub fn into_id(self, loc: Location) -> ExprNodeId {
+        self.into_id_inner(Some(loc))
     }
 
     // For testing purposes

--- a/mimium-lang/src/ast/builder.rs
+++ b/mimium-lang/src/ast/builder.rs
@@ -17,27 +17,27 @@ macro_rules! dummy_span {
 #[macro_export]
 macro_rules! number {
     ($n:literal) => {
-        Expr::Literal(Literal::Float(crate::ast::builder::str_to_symbol($n))).into_id(0..0)
+        Expr::Literal(Literal::Float(crate::ast::builder::str_to_symbol($n))).into_id_without_span()
     };
 }
 
 #[macro_export]
 macro_rules! string {
     ($n:expr) => {
-        Expr::Literal(Literal::String($n)).into_id(0..0)
+        Expr::Literal(Literal::String($n)).into_id_without_span()
     };
 }
 #[macro_export]
 macro_rules! var {
     ($n:literal) => {
-        Expr::Var($crate::ast::builder::str_to_symbol($n)).into_id(0..0)
+        Expr::Var($crate::ast::builder::str_to_symbol($n)).into_id_without_span()
     };
 }
 
 #[macro_export]
 macro_rules! app {
     ($a:expr,$b:expr) => {
-        Expr::Apply($a, $b).into_id(0..0)
+        Expr::Apply($a, $b).into_id_without_span()
     };
 }
 
@@ -63,13 +63,13 @@ macro_rules! lambda {
                 .iter()
                 .map(|a: &&'static str| $crate::pattern::TypedId {
                     id: $crate::ast::builder::str_to_symbol(a),
-                    ty: $crate::types::Type::Unknown.into_id_with_span(0..0),
+                    ty: $crate::types::Type::Unknown.into_id(),
                 })
                 .collect::<Vec<_>>(),
             None,
             $body,
         )
-        .into_id(0..0)
+        .into_id_without_span()
     };
 }
 
@@ -79,12 +79,12 @@ macro_rules! let_ {
         Expr::Let(
             $crate::pattern::TypedPattern {
                 pat: $crate::pattern::Pattern::Single($crate::ast::builder::str_to_symbol($id)),
-                ty: $crate::types::Type::Unknown.into_id_with_span(0..0),
+                ty: $crate::types::Type::Unknown.into_id(),
             },
             $body,
             Some($then),
         )
-        .into_id(0..0)
+        .into_id_without_span()
     };
     ($id:literal,$body:expr) => {
         Expr::Let(
@@ -105,12 +105,12 @@ macro_rules! letrec {
         Expr::LetRec(
             TypedId {
                 id: $crate::ast::builder::str_to_symbol($id),
-                ty: $ty.unwrap_or($crate::types::Type::Unknown.into_id_with_span(0..0)),
+                ty: $ty.unwrap_or($crate::types::Type::Unknown.into_id()),
             },
             $body,
             $then,
         )
-        .into_id(0..0)
+        .into_id_without_span()
     };
 }
 
@@ -130,6 +130,6 @@ macro_rules! then {
 #[macro_export]
 macro_rules! ifexpr {
     ($cond:expr,$then:expr,$else_:expr) => {
-        Expr::If($cond, $then, Some($else_)).into_id(0..0)
+        Expr::If($cond, $then, Some($else_)).into_id_without_span()
     };
 }

--- a/mimium-lang/src/compiler.rs
+++ b/mimium-lang/src/compiler.rs
@@ -127,8 +127,8 @@ impl Context {
         let ast = parser::add_global_context(ast, self.file_path.unwrap_or_default());
         let mir = mirgen::compile(ast, &self.get_ext_typeinfos(), self.file_path);
         mir.map_err(|mut e| {
-            e.append(&mut parse_errs);
-            e
+            parse_errs.append(&mut e);
+            parse_errs
         })
     }
     pub fn emit_bytecode(&self, src: &str) -> Result<vm::Program, Vec<Box<dyn ReportableError>>> {

--- a/mimium-lang/src/compiler/bytecodegen.rs
+++ b/mimium-lang/src/compiler/bytecodegen.rs
@@ -6,7 +6,7 @@ use crate::mir::{self, Mir, StateSize};
 use crate::runtime::vm::bytecode::{ConstPos, GlobalPos, Reg};
 use crate::runtime::vm::{self, StateOffset};
 use crate::types::{PType, Type, TypeSize};
-use crate::utils::{error::ReportableError, half_float::HFloat};
+use crate::utils::half_float::HFloat;
 use vm::bytecode::Instruction as VmInstruction;
 
 #[derive(Debug, Default)]

--- a/mimium-lang/src/compiler/bytecodegen.rs
+++ b/mimium-lang/src/compiler/bytecodegen.rs
@@ -784,10 +784,10 @@ fn optimize(program: vm::Program) -> vm::Program {
     // remove_redundunt_mov(program);
     program
 }
-pub fn gen_bytecode(mir: mir::Mir) -> Result<vm::Program, Vec<Box<dyn ReportableError>>> {
+pub fn gen_bytecode(mir: mir::Mir) -> vm::Program {
     let mut generator = ByteCodeGenerator::default();
     let program = generator.generate(mir);
-    Ok(optimize(program))
+    optimize(program)
 }
 
 #[cfg(test)]

--- a/mimium-lang/src/compiler/mirgen.rs
+++ b/mimium-lang/src/compiler/mirgen.rs
@@ -1,5 +1,5 @@
 use super::intrinsics;
-use super::typing::{self, infer_root, InferContext};
+use super::typing::{infer_root, InferContext};
 use crate::interner::{ExprNodeId, Symbol, ToSymbol, TypeNodeId};
 use crate::pattern::{Pattern, TypedId, TypedPattern};
 use crate::{function, numeric, unit};
@@ -12,10 +12,10 @@ use std::sync::Arc;
 use crate::types::{PType, Type};
 use crate::utils::environment::{Environment, LookupRes};
 use crate::utils::error::ReportableError;
-use crate::utils::metadata::Span;
+use crate::utils::metadata::{Location, Span};
 
 use crate::ast::{Expr, Literal};
-use itertools::Itertools;
+// use itertools::Itertools;
 
 // pub mod closure_convert;
 // pub mod feedconvert;
@@ -45,17 +45,20 @@ pub struct Context {
 }
 
 impl Context {
-    pub fn new(typeenv: InferContext) -> Self {
+    pub fn new(typeenv: InferContext, file_path: Option<Symbol>) -> Self {
         Self {
             typeenv,
             valenv: Environment::new(),
-            program: Default::default(),
+            program: Mir::new(file_path),
             reg_count: 0,
             fn_label: None,
             anonymous_fncount: 0,
             data: vec![ContextData::default()],
             data_i: 0,
         }
+    }
+    fn get_loc_from_span(&self, span: &Span) -> Location {
+        Location::new(span.clone(), self.program.file_path.unwrap_or_default())
     }
     fn get_ctxdata(&mut self) -> &mut ContextData {
         self.data.get_mut(self.data_i).unwrap()
@@ -75,20 +78,20 @@ impl Context {
         let i = self.get_ctxdata().func_i;
         &mut self.program.functions[i]
     }
-    fn make_delay(&mut self, f: &VPtr, args: &[ExprNodeId]) -> Result<Option<VPtr>, CompileError> {
+    fn try_make_delay(&mut self, f: &VPtr, args: &[ExprNodeId]) -> Option<VPtr> {
         let rt = match f.as_ref() {
             Value::ExtFunction(name, ft) if *name == "delay".to_symbol() => ft,
-            _ => return Ok(None),
+            _ => return None,
         };
 
         let (max, src, time) = match args {
             [max, src, time] => (max, src, time),
-            _ => return Ok(None),
+            _ => return None,
         };
         match max.to_expr() {
             Expr::Literal(Literal::Float(max)) => {
                 //need to evaluate args first before calculate state offset because the argument for time contains stateful function call.
-                let args = self.eval_args(&[*src, *time])?;
+                let args = self.eval_args(&[*src, *time]);
                 let max_time = max.as_str().parse::<f64>().unwrap();
                 let shift_size = max_time as u64 + DELAY_ADDITIONAL_OFFSET;
                 self.get_current_fn().state_sizes.push(StateSize {
@@ -103,16 +106,13 @@ impl Context {
                         .push((Arc::new(Value::None), Instruction::PushStateOffset(coffset)));
                 }
                 let (args, _types): (Vec<VPtr>, Vec<TypeNodeId>) = args.into_iter().unzip();
-                Ok(Some(self.push_inst(Instruction::Delay(
+                Some(self.push_inst(Instruction::Delay(
                     max_time as u64,
                     args[0].clone(),
                     args[1].clone(),
-                ))))
+                )))
             }
-            _ => Err(CompileError(
-                CompileErrorKind::UnboundedDelay,
-                max.to_span().clone(),
-            )),
+            _ => unreachable!("unbounded delay access, should be an error at typing stage."),
         }
     }
     fn make_binop_intrinsic(
@@ -166,17 +166,13 @@ impl Context {
         }
     }
 
-    fn make_intrinsics(
-        &mut self,
-        label: Symbol,
-        args: &[(VPtr, TypeNodeId)],
-    ) -> Result<Option<VPtr>, CompileError> {
+    fn make_intrinsics(&mut self, label: Symbol, args: &[(VPtr, TypeNodeId)]) -> Option<VPtr> {
         let inst = match args.len() {
             1 => self.make_uniop_intrinsic(label, args),
             2 => self.make_binop_intrinsic(label, args),
-            _ => return Ok(None),
+            _ => return None,
         };
-        Ok(inst.map(|i| self.push_inst(i)))
+        inst.map(|i| self.push_inst(i))
     }
     fn get_current_basicblock(&mut self) -> &mut mir::Block {
         let bbid = self.get_ctxdata().current_bb;
@@ -208,7 +204,7 @@ impl Context {
         v: VPtr,
         ty: TypeNodeId,
         is_global: bool,
-    ) -> Result<(), CompileError> {
+    ) {
         let TypedPattern { pat, .. } = pattern;
         let span = pattern.to_span();
         match (pat, ty.to_type()) {
@@ -233,19 +229,18 @@ impl Context {
                         array_idx: 0,
                         tuple_offset: i as u64,
                     });
-                    let tid = Type::Unknown.into_id_with_span(span.clone());
+                    let tid = Type::Unknown.into_id_with_location(self.get_loc_from_span(&span));
                     let tpat = TypedPattern {
                         pat: pat.clone(),
                         ty: tid,
                     };
-                    self.add_bind_pattern(&tpat, elem_v, *cty, is_global)?;
+                    self.add_bind_pattern(&tpat, elem_v, *cty, is_global);
                 }
             }
             _ => {
                 panic!("typing error in the previous stage")
             }
         }
-        Ok(())
     }
     fn make_new_function(
         &mut self,
@@ -259,13 +254,13 @@ impl Context {
         self.program.functions.push(newf);
         index
     }
-    fn do_in_child_ctx<F: FnMut(&mut Self, usize) -> Result<(VPtr, TypeNodeId), CompileError>>(
+    fn do_in_child_ctx<F: FnMut(&mut Self, usize) -> (VPtr, TypeNodeId)>(
         &mut self,
         fname: Symbol,
         abinds: &[(Symbol, VPtr)],
         types: &[TypeNodeId],
         mut action: F,
-    ) -> Result<(usize, VPtr), CompileError> {
+    ) -> (usize, VPtr) {
         self.valenv.extend();
         self.valenv.add_bind(abinds);
         let args = abinds.iter().map(|(_, a)| a.clone()).collect::<Vec<_>>();
@@ -278,7 +273,7 @@ impl Context {
         });
         self.data_i += 1;
         //do action
-        let (fptr, ty) = action(self, c_idx)?;
+        let (fptr, ty) = action(self, c_idx);
 
         // TODO: ideally, type should be infered before the actual action
         let f = self.program.functions.get_mut(c_idx).unwrap();
@@ -288,7 +283,7 @@ impl Context {
         let _ = self.data.pop();
         self.data_i -= 1;
         self.valenv.to_outer();
-        Ok((c_idx, fptr))
+        (c_idx, fptr)
     }
     fn lookup(&self, key: &Symbol) -> LookupRes<VPtr> {
         match self.valenv.lookup_cls(key) {
@@ -299,7 +294,7 @@ impl Context {
         }
     }
 
-    pub fn eval_literal(&mut self, lit: &Literal, _span: &Span) -> Result<VPtr, CompileError> {
+    pub fn eval_literal(&mut self, lit: &Literal, _span: &Span) -> VPtr {
         let v = match lit {
             Literal::String(s) => self.push_inst(Instruction::String(*s)),
             Literal::Int(i) => self.push_inst(Instruction::Integer(*i)),
@@ -323,14 +318,10 @@ impl Context {
             }
             Literal::SelfLit | Literal::PlaceHolder => unreachable!(),
         };
-        Ok(v)
+        v
     }
-    fn eval_rvar(
-        &mut self,
-        name: Symbol,
-        t: TypeNodeId,
-        span: &Span,
-    ) -> Result<VPtr, CompileError> {
+    fn eval_rvar(&mut self, name: Symbol, t: TypeNodeId, span: &Span) -> VPtr {
+        let loc = self.get_loc_from_span(span);
         log::trace!("rv t:{} {}", name.to_string(), t.to_type());
         let v = match self.lookup(&name) {
             LookupRes::Local(v) => match v.as_ref() {
@@ -366,20 +357,14 @@ impl Context {
             LookupRes::None => {
                 let ty = self
                     .typeenv
-                    .lookup(&name, span)
-                    .map_err(CompileError::from)?;
+                    .lookup(name, loc)
+                    .expect("variable not found. it should be detected at type checking stage");
                 Arc::new(Value::ExtFunction(name, ty))
             }
         };
-        Ok(v)
+        v
     }
-    fn eval_assign(
-        &mut self,
-        assignee: ExprNodeId,
-        src: VPtr,
-        t: TypeNodeId,
-        span: &Span,
-    ) -> Result<(), CompileError> {
+    fn eval_assign(&mut self, assignee: ExprNodeId, src: VPtr, t: TypeNodeId, _span: &Span) {
         let name = match assignee.to_expr() {
             Expr::Var(v) => v,
             Expr::ArrayAccess(_, _) => {
@@ -389,13 +374,12 @@ impl Context {
         };
         match self.lookup(&name) {
             LookupRes::Local(v) => match v.as_ref() {
-                Value::Argument(_i, _a) => Err(CompileError(
-                    CompileErrorKind::AssignmentToArg,
-                    span.clone(),
-                )),
+                Value::Argument(_i, a) => {
+                    log::warn!("assignment to argument {name} does not affect to the external environments.");
+                    self.push_inst(Instruction::Store(v.clone(), src, t));
+                }
                 _ => {
                     self.push_inst(Instruction::Store(v.clone(), src, t));
-                    Ok(())
                 }
             },
             LookupRes::UpValue(_level, upv) => {
@@ -403,12 +387,10 @@ impl Context {
                 let currentf = self.get_current_fn();
                 let upi = currentf.get_or_insert_upvalue(&upv) as _;
                 self.push_inst(Instruction::SetUpValue(upi, src, t));
-                Ok(())
             }
             LookupRes::Global(dst) => match dst.as_ref() {
                 Value::Global(_gv) => {
                     self.push_inst(Instruction::SetGlobal(dst.clone(), src.clone(), t));
-                    Ok(())
                 }
                 _ => unreachable!("non global_value"),
             },
@@ -448,10 +430,10 @@ impl Context {
 
         res
     }
-    fn eval_args(&mut self, args: &[ExprNodeId]) -> Result<Vec<(VPtr, TypeNodeId)>, CompileError> {
+    fn eval_args(&mut self, args: &[ExprNodeId]) -> Vec<(VPtr, TypeNodeId)> {
         args.iter()
-            .map(|a_meta| -> Result<_, CompileError> {
-                let (v, t) = self.eval_expr(*a_meta)?;
+            .map(|a_meta| {
+                let (v, t) = self.eval_expr(*a_meta);
                 let res = match v.as_ref() {
                     Value::Function(idx) => {
                         let f = self.push_inst(Instruction::Uinteger(*idx as u64));
@@ -463,19 +445,16 @@ impl Context {
                     //higher-order function need to close immidiately
                     self.push_inst(Instruction::CloseUpValues(res.clone(), t));
                 }
-                Ok((res, t))
+                (res, t)
             })
-            .try_collect()
+            .collect()
     }
-    fn eval_block(
-        &mut self,
-        block: Option<ExprNodeId>,
-    ) -> Result<(VPtr, TypeNodeId), CompileError> {
+    fn eval_block(&mut self, block: Option<ExprNodeId>) -> (VPtr, TypeNodeId) {
         self.add_new_basicblock();
         let (e, rt) = match block {
             Some(e) => self.eval_expr(e),
-            None => Ok((Arc::new(Value::None), unit!())),
-        }?;
+            None => (Arc::new(Value::None), unit!()),
+        };
         //if returning non-closure function, make closure
         let e = match e.as_ref() {
             Value::Function(idx) => {
@@ -484,23 +463,24 @@ impl Context {
             }
             _ => e,
         };
-        Ok((e, rt))
+        (e, rt)
     }
-    pub fn eval_expr(&mut self, e: ExprNodeId) -> Result<(VPtr, TypeNodeId), CompileError> {
+    pub fn eval_expr(&mut self, e: ExprNodeId) -> (VPtr, TypeNodeId) {
         let span = e.to_span();
         let ty = self.typeenv.lookup_res(e);
         match &e.to_expr() {
             Expr::Literal(lit) => {
-                let v = self.eval_literal(lit, &span)?;
-                let t = InferContext::infer_type_literal(lit).map_err(CompileError::from)?;
-                Ok((v, t))
+                let v = self.eval_literal(lit, &span);
+                let t = InferContext::infer_type_literal(lit)
+                    .expect("should be an error at type checker stage");
+                (v, t)
             }
-            Expr::Var(name) => Ok((self.eval_rvar(*name, ty, &span)?, ty)),
+            Expr::Var(name) => (self.eval_rvar(*name, ty, &span), ty),
             Expr::Block(b) => {
                 if let Some(block) = b {
                     self.eval_expr(*block)
                 } else {
-                    Ok((Arc::new(Value::None), unit!()))
+                    (Arc::new(Value::None), unit!())
                 }
             }
             Expr::Tuple(items) => {
@@ -511,7 +491,7 @@ impl Context {
                 let alloc_insert_point = self.get_current_basicblock().0.len();
                 let dst = self.gen_new_register();
                 for (i, e) in items.iter().enumerate() {
-                    let (v, elem_ty) = self.eval_expr(*e)?;
+                    let (v, elem_ty) = self.eval_expr(*e);
                     let ptr = self.push_inst(Instruction::GetElement {
                         value: dst.clone(),
                         ty, // lazyly set after loops
@@ -527,18 +507,18 @@ impl Context {
 
                 // pass only the head of the tuple, and the length can be known
                 // from the type information.
-                Ok((dst, ty))
+                (dst, ty)
             }
             Expr::Proj(_, _) => todo!(),
             Expr::ArrayAccess(_, _) => todo!(),
 
             Expr::Apply(f, args) => {
-                let (f, ft) = self.eval_expr(*f)?;
-                let del = self.make_delay(&f, args)?;
+                let (f, ft) = self.eval_expr(*f);
+                let del = self.try_make_delay(&f, args);
                 if let Some(d) = del {
-                    Ok((d, numeric!()))
+                    (d, numeric!())
                 } else {
-                    let atvvec = self.eval_args(args)?;
+                    let atvvec = self.eval_args(args);
                     let rt = if let Type::Function(_, rt, _) = ft.to_type() {
                         rt
                     } else {
@@ -563,7 +543,7 @@ impl Context {
                         }
                         Value::Function(idx) => self.emit_fncall(*idx as u64, atvvec.clone(), rt),
                         Value::ExtFunction(label, _ty) => {
-                            if let Some(res) = self.make_intrinsics(*label, &atvvec)? {
+                            if let Some(res) = self.make_intrinsics(*label, &atvvec) {
                                 res
                             } else {
                                 self.push_inst(Instruction::Call(f.clone(), atvvec.clone(), rt))
@@ -573,7 +553,7 @@ impl Context {
                         Value::None => unreachable!(),
                         _ => todo!(),
                     };
-                    Ok((res, rt))
+                    (res, rt)
                 }
             }
             Expr::PipeApply(_, _) => unreachable!(),
@@ -595,7 +575,7 @@ impl Context {
 
                 let name = self.consume_fnlabel();
                 let (c_idx, f) = self.do_in_child_ctx(name, &binds, &atypes, |ctx, c_idx| {
-                    let (res, _) = ctx.eval_expr(*body)?;
+                    let (res, _) = ctx.eval_expr(*body);
 
                     let push_sum = ctx.get_ctxdata().push_sum.clone();
                     if !push_sum.is_empty() {
@@ -628,8 +608,8 @@ impl Context {
                     };
 
                     let f = Arc::new(Value::Function(c_idx));
-                    Ok((f, rt))
-                })?;
+                    (f, rt)
+                });
                 let child = self.program.functions.get_mut(c_idx).unwrap();
                 let res = if child.upindexes.is_empty() {
                     //todo:make Closure
@@ -638,7 +618,7 @@ impl Context {
                     let idxcell = self.push_inst(Instruction::Uinteger(c_idx as u64));
                     self.push_inst(Instruction::Closure(idxcell))
                 };
-                Ok((res, ty))
+                (res, ty)
             }
             Expr::Feed(id, expr) => {
                 //set typesize lazily
@@ -647,9 +627,9 @@ impl Context {
                 self.get_ctxdata().cur_state_pos.push(statesize);
                 self.add_bind((*id, res.clone()));
                 self.get_ctxdata().next_state_offset = Some(vec![statesize]);
-                let (retv, _t) = self.eval_expr(*expr)?;
+                let (retv, _t) = self.eval_expr(*expr);
                 self.get_current_fn().state_sizes.push(statesize);
-                Ok((Arc::new(Value::State(retv)), ty))
+                (Arc::new(Value::State(retv)), ty)
             }
             Expr::Let(pat, body, then) => {
                 if let Ok(tid) = TypedId::try_from(pat.clone()) {
@@ -665,7 +645,7 @@ impl Context {
                 } else {
                     self.get_current_basicblock().0.len()
                 };
-                let (bodyv, t) = self.eval_expr(*body)?;
+                let (bodyv, t) = self.eval_expr(*body);
                 //todo:need to boolean and insert cast
                 self.fn_label = None;
 
@@ -680,14 +660,14 @@ impl Context {
                         block.insert(insert_pos, (alloc_res.clone(), Instruction::Alloc(t)));
                         let _ =
                             self.push_inst(Instruction::Store(alloc_res.clone(), bodyv.clone(), t));
-                        self.add_bind_pattern(pat, alloc_res, t, false)?;
+                        self.add_bind_pattern(pat, alloc_res, t, false);
                         self.eval_expr(*then_e)
                     }
                     (is_global, _, Some(then_e)) => {
-                        self.add_bind_pattern(pat, bodyv, t, is_global)?;
+                        self.add_bind_pattern(pat, bodyv, t, is_global);
                         self.eval_expr(*then_e)
                     }
-                    (_, _, None) => Ok((Arc::new(Value::None), unit!())),
+                    (_, _, None) => (Arc::new(Value::None), unit!()),
                 }
             }
             Expr::LetRec(id, body, then) => {
@@ -703,30 +683,30 @@ impl Context {
                 };
                 let bind = (id.id, v.clone());
                 self.add_bind(bind);
-                let (b, _bt) = self.eval_expr(*body)?;
+                let (b, _bt) = self.eval_expr(*body);
                 if !is_global {
                     let _ = self.push_inst(Instruction::Store(v.clone(), b.clone(), t));
                 }
                 if let Some(then_e) = then {
                     self.eval_expr(*then_e)
                 } else {
-                    Ok((Arc::new(Value::None), unit!()))
+                    (Arc::new(Value::None), unit!())
                 }
             }
             Expr::Assign(assignee, body) => {
-                let (src, ty) = self.eval_expr(*body)?;
-                self.eval_assign(*assignee, src, ty, &span)?;
-                Ok((Arc::new(Value::None), unit!()))
+                let (src, ty) = self.eval_expr(*body);
+                self.eval_assign(*assignee, src, ty, &span);
+                (Arc::new(Value::None), unit!())
             }
             Expr::Then(body, then) => {
-                let _ = self.eval_expr(*body)?;
+                let _ = self.eval_expr(*body);
                 match then {
                     Some(t) => self.eval_expr(*t),
-                    None => Ok((Arc::new(Value::None), unit!())),
+                    None => (Arc::new(Value::None), unit!()),
                 }
             }
             Expr::If(cond, then, else_) => {
-                let (c, _) = self.eval_expr(*cond)?;
+                let (c, _) = self.eval_expr(*cond);
                 let cond_bidx = self.get_ctxdata().current_bb;
 
                 // This is just a placeholder. At this point, the locations of
@@ -736,11 +716,11 @@ impl Context {
 
                 //insert then block
                 let then_bidx = cond_bidx + 1;
-                let (t, _) = self.eval_block(Some(*then))?;
+                let (t, _) = self.eval_block(Some(*then));
                 //jmp to ret is inserted in bytecodegen
                 //insert else block
                 let else_bidx = self.get_ctxdata().current_bb + 1;
-                let (e, _) = self.eval_block(*else_)?;
+                let (e, _) = self.eval_block(*else_);
                 //insert return block
                 self.add_new_basicblock();
                 let res = self.push_inst(Instruction::Phi(t, e));
@@ -764,7 +744,7 @@ impl Context {
                     _ => panic!("the last block should be Jmp"),
                 }
 
-                Ok((res, ty))
+                (res, ty)
             }
             Expr::Bracket(_) => todo!(),
             Expr::Escape(_) => todo!(),
@@ -773,61 +753,29 @@ impl Context {
     }
 }
 
-#[derive(Clone, Debug)]
-pub enum CompileErrorKind {
-    TypingFailure(typing::ErrorKind),
-    AssignmentToArg,
-    UnboundedDelay,
-    TooManyConstants,
-    VariableNotFound(String),
-}
-#[derive(Clone, Debug)]
-pub struct CompileError(CompileErrorKind, Span);
-
-impl std::fmt::Display for CompileError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let CompileError(kind, _span) = self;
-        match kind {
-            CompileErrorKind::TypingFailure(k) => write!(f, "{k}"),
-            CompileErrorKind::AssignmentToArg => write!(f, "Arguments can not be mutated"),
-            CompileErrorKind::UnboundedDelay => {
-                write!(f, "Maximium delay time needs to be a number literal.")
-            }
-
-            CompileErrorKind::TooManyConstants => write!(f, "too many constants."),
-            CompileErrorKind::VariableNotFound(s) => write!(f, "Variable {s} not found."),
-        }
-    }
-}
-impl std::error::Error for CompileError {}
-impl From<typing::Error> for CompileError {
-    fn from(value: typing::Error) -> Self {
-        Self(CompileErrorKind::TypingFailure(value.0), value.1)
-    }
-}
-impl ReportableError for CompileError {
-    fn get_span(&self) -> std::ops::Range<usize> {
-        self.1.clone()
-    }
-}
-
 pub fn compile(
     root_expr_id: ExprNodeId,
     builtin_types: &[(Symbol, TypeNodeId)],
     file_path: Option<Symbol>,
-) -> Result<Mir, Box<dyn ReportableError>> {
-    let ast2 = recursecheck::convert_recurse(root_expr_id);
-    let expr2 = convert_pronoun::convert_pronoun(ast2).map_err(|e| {
-        let eb: Box<dyn ReportableError> = Box::new(e);
-        eb
-    })?;
-    let infer_ctx = infer_root(expr2, builtin_types)
-        .map_err(|err| Box::new(CompileError::from(err)) as Box<dyn ReportableError>)?;
-    let mut ctx = Context::new(infer_ctx);
-    let _res = ctx.eval_expr(expr2).map_err(|e| {
-        let eb: Box<dyn ReportableError> = Box::new(e);
-        eb
-    })?;
+) -> (Mir, Vec<Box<dyn ReportableError>>) {
+    let ast2 = recursecheck::convert_recurse(root_expr_id, file_path.unwrap_or_default());
+    let (expr2, convert_errs) =
+        convert_pronoun::convert_pronoun(ast2, file_path.unwrap_or_default());
+    let infer_ctx = infer_root(expr2, builtin_types);
+    let errors = infer_ctx
+        .errors
+        .iter()
+        .cloned()
+        .map(|e| -> Box<dyn ReportableError> { Box::new(e) })
+        .chain(
+            convert_errs
+                .into_iter()
+                .map(|e| -> Box<dyn ReportableError> { Box::new(e) }),
+        )
+        .collect::<Vec<_>>();
+
+    let mut ctx = Context::new(infer_ctx, file_path);
+    let _res = ctx.eval_expr(expr2);
     ctx.program.file_path = file_path;
-    Ok(ctx.program.clone())
+    (ctx.program.clone(), errors)
 }

--- a/mimium-lang/src/compiler/mirgen.rs
+++ b/mimium-lang/src/compiler/mirgen.rs
@@ -764,7 +764,7 @@ pub fn compile(
     let ast2 = recursecheck::convert_recurse(root_expr_id, file_path.unwrap_or_default());
     let (expr2, convert_errs) =
         convert_pronoun::convert_pronoun(ast2, file_path.unwrap_or_default());
-    let infer_ctx = infer_root(expr2, builtin_types);
+    let infer_ctx = infer_root(expr2, builtin_types, file_path.unwrap_or_default());
     let errors = infer_ctx
         .errors
         .iter()

--- a/mimium-lang/src/compiler/parser/resolve_include.rs
+++ b/mimium-lang/src/compiler/parser/resolve_include.rs
@@ -1,12 +1,12 @@
-use super::{parse, Span};
-use crate::interner::ExprNodeId;
-use crate::utils::error::{ReportableError, ReportableErrorDyn};
+use super::{parse, Location, Span};
+use crate::interner::{ExprNodeId, ToSymbol};
+use crate::utils::error::{ReportableError, SimpleError};
 use crate::utils::fileloader;
 
-fn make_vec_error<E: std::error::Error>(e: E, span: Span) -> Vec<Box<dyn ReportableError>> {
-    vec![Box::new(ReportableErrorDyn {
+fn make_vec_error<E: std::error::Error>(e: E, loc: Location) -> Vec<Box<dyn ReportableError>> {
+    vec![Box::new(SimpleError {
         message: e.to_string(),
-        span: span.clone(),
+        span: loc,
     }) as Box<dyn ReportableError>]
 }
 
@@ -15,9 +15,13 @@ pub(super) fn resolve_include(
     target_path: &str,
     span: Span,
 ) -> Result<ExprNodeId, Vec<Box<dyn ReportableError>>> {
+    let loc = Location {
+        span: span.clone(),
+        path: mmm_filepath.to_symbol(),
+    };
     let abspath = fileloader::get_canonical_path(mmm_filepath, target_path)
-        .map_err(|e| make_vec_error(e, span.clone()))?;
+        .map_err(|e| make_vec_error(e, loc.clone()))?;
     let content =
-        fileloader::load(abspath.to_str().unwrap()).map_err(|e| make_vec_error(e, span.clone()))?;
+        fileloader::load(abspath.to_str().unwrap()).map_err(|e| make_vec_error(e, loc))?;
     parse(&content, Some(abspath))
 }

--- a/mimium-lang/src/compiler/parser/test.rs
+++ b/mimium-lang/src/compiler/parser/test.rs
@@ -22,18 +22,24 @@ macro_rules! test_string {
         }
     };
 }
-
+//dummy location
+fn loc(span: Span) -> Location {
+    Location {
+        span,
+        path: "/".to_symbol(),
+    }
+}
 #[test]
 fn test_let() {
     let ans = Expr::Let(
         TypedPattern {
             pat: Pattern::Single("goge".to_symbol()),
-            ty: Type::Unknown.into_id_with_span(4..8),
+            ty: Type::Unknown.into_id_with_location(loc(4..8)),
         },
-        Expr::Literal(Literal::Float("36".to_symbol())).into_id(11..13),
-        Some(Expr::Var("goge".to_symbol()).into_id(15..19)),
+        Expr::Literal(Literal::Float("36".to_symbol())).into_id(loc(11..13)),
+        Some(Expr::Var("goge".to_symbol()).into_id(loc(15..19))),
     )
-    .into_id(0..19);
+    .into_id(loc(0..19));
     test_string!("let goge = 36\n goge", ans);
 }
 #[test]
@@ -44,47 +50,47 @@ fn test_lettuple() {
                 Pattern::Single("a".to_symbol()),
                 Pattern::Single("b".to_symbol()),
             ]),
-            ty: Type::Unknown.into_id_with_span(4..9),
+            ty: Type::Unknown.into_id_with_location(loc(4..9)),
         },
         Expr::Tuple(vec![
-            Expr::Literal(Literal::Float("36".to_symbol())).into_id(13..15),
-            Expr::Literal(Literal::Float("89".to_symbol())).into_id(16..18),
+            Expr::Literal(Literal::Float("36".to_symbol())).into_id(loc(13..15)),
+            Expr::Literal(Literal::Float("89".to_symbol())).into_id(loc(16..18)),
         ])
-        .into_id(12..19),
-        Some(Expr::Var("hoge".to_symbol()).into_id(21..25)),
+        .into_id(loc(12..19)),
+        Some(Expr::Var("hoge".to_symbol()).into_id(loc(21..25))),
     )
-    .into_id(0..25);
+    .into_id(loc(0..25));
     test_string!("let (a,b) = (36,89)\n hoge", ans);
 }
 #[test]
 fn test_if() {
     let ans = Expr::If(
-        Expr::Literal(Literal::Float("100".to_symbol())).into_id(4..7),
-        Expr::Var("hoge".to_symbol()).into_id(9..13),
-        Some(Expr::Var("fuga".to_symbol()).into_id(19..23)),
+        Expr::Literal(Literal::Float("100".to_symbol())).into_id(loc(4..7)),
+        Expr::Var("hoge".to_symbol()).into_id(loc(9..13)),
+        Some(Expr::Var("fuga".to_symbol()).into_id(loc(19..23))),
     )
-    .into_id(0..23);
+    .into_id(loc(0..23));
     test_string!("if (100) hoge else fuga", ans);
 }
 #[test]
 fn test_if_noelse() {
     let ans = Expr::If(
-        Expr::Literal(Literal::Float("100".to_symbol())).into_id(4..7),
-        Expr::Var("hoge".to_symbol()).into_id(9..13),
+        Expr::Literal(Literal::Float("100".to_symbol())).into_id(loc(4..7)),
+        Expr::Var("hoge".to_symbol()).into_id(loc(9..13)),
         None,
     )
-    .into_id(0..13);
+    .into_id(loc(0..13));
     test_string!("if (100) hoge ", ans);
 }
 
 #[test]
 fn test_int() {
-    let ans = Expr::Literal(Literal::Float("3466".to_symbol())).into_id(0..4);
+    let ans = Expr::Literal(Literal::Float("3466".to_symbol())).into_id(loc(0..4));
     test_string!("3466", ans);
 }
 #[test]
 fn test_string() {
-    let ans = Expr::Literal(Literal::String("teststr".to_symbol())).into_id(0..9);
+    let ans = Expr::Literal(Literal::String("teststr".to_symbol())).into_id(loc(0..9));
     test_string!("\"teststr\"", ans);
 }
 #[test]
@@ -93,14 +99,14 @@ fn test_block() {
         Expr::Let(
             TypedPattern {
                 pat: Pattern::Single("hoge".to_symbol()),
-                ty: Type::Unknown.into_id_with_span(5..9),
+                ty: Type::Unknown.into_id_with_location(loc(5..9)),
             },
-            Expr::Literal(Literal::Float("100".to_symbol())).into_id(12..15),
-            Some(Expr::Var("hoge".to_symbol()).into_id(16..20)),
+            Expr::Literal(Literal::Float("100".to_symbol())).into_id(loc(12..15)),
+            Some(Expr::Var("hoge".to_symbol()).into_id(loc(16..20))),
         )
-        .into_id(1..20),
+        .into_id(loc(1..20)),
     ))
-    .into_id(0..21);
+    .into_id(loc(0..21));
     test_string!(
         "{let hoge = 100
 hoge}",
@@ -110,54 +116,54 @@ hoge}",
 #[test]
 fn test_add() {
     let ans = Expr::Apply(
-        Expr::Var("add".to_symbol()).into_id(6..7),
+        Expr::Var("add".to_symbol()).into_id(loc(6..7)),
         vec![
-            Expr::Literal(Literal::Float("3466.0".to_symbol())).into_id(0..6),
-            Expr::Literal(Literal::Float("2000.0".to_symbol())).into_id(7..13),
+            Expr::Literal(Literal::Float("3466.0".to_symbol())).into_id(loc(0..6)),
+            Expr::Literal(Literal::Float("2000.0".to_symbol())).into_id(loc(7..13)),
         ],
     )
-    .into_id(0..13);
+    .into_id(loc(0..13));
     test_string!("3466.0+2000.0", ans);
 }
 #[test]
 fn test_at() {
     let ans1 = Expr::Apply(
-        Expr::Var("_mimium_schedule_at".to_symbol()).into_id(3..4),
+        Expr::Var("_mimium_schedule_at".to_symbol()).into_id(loc(3..4)),
         vec![
-            Expr::Literal(Literal::Float("1.0".to_symbol())).into_id(4..7),
-            Expr::Var("foo".to_symbol()).into_id(0..3),
+            Expr::Literal(Literal::Float("1.0".to_symbol())).into_id(loc(4..7)),
+            Expr::Var("foo".to_symbol()).into_id(loc(0..3)),
         ],
     )
-    .into_id(0..7);
+    .into_id(loc(0..7));
     test_string!("foo@1.0", ans1);
 
     let time = Expr::Apply(
-        Expr::Var("pow".to_symbol()).into_id(7..8),
+        Expr::Var("pow".to_symbol()).into_id(loc(7..8)),
         vec![
-            Expr::Literal(Literal::Float("1.0".to_symbol())).into_id(4..7),
-            Expr::Literal(Literal::Float("2.0".to_symbol())).into_id(8..11),
+            Expr::Literal(Literal::Float("1.0".to_symbol())).into_id(loc(4..7)),
+            Expr::Literal(Literal::Float("2.0".to_symbol())).into_id(loc(8..11)),
         ],
     )
-    .into_id(4..11);
+    .into_id(loc(4..11));
     let ans2 = Expr::Apply(
-        Expr::Var("_mimium_schedule_at".to_symbol()).into_id(3..4),
-        vec![time, Expr::Var("foo".to_symbol()).into_id(0..3)],
+        Expr::Var("_mimium_schedule_at".to_symbol()).into_id(loc(3..4)),
+        vec![time, Expr::Var("foo".to_symbol()).into_id(loc(0..3))],
     )
-    .into_id(0..11);
+    .into_id(loc(0..11));
     test_string!("foo@1.0^2.0", ans2);
 }
 #[test]
 fn test_var() {
-    let ans = Expr::Var("hoge".to_symbol()).into_id(0..4);
+    let ans = Expr::Var("hoge".to_symbol()).into_id(loc(0..4));
     test_string!("hoge", ans);
 }
 #[test]
 fn test_apply() {
     let ans = Expr::Apply(
-        Expr::Var("myfun".to_symbol()).into_id(0..5),
-        vec![Expr::Var("callee".to_symbol()).into_id(6..12)],
+        Expr::Var("myfun".to_symbol()).into_id(loc(0..5)),
+        vec![Expr::Var("callee".to_symbol()).into_id(loc(6..12))],
     )
-    .into_id(0..13);
+    .into_id(loc(0..13));
     test_string!("myfun(callee)", ans);
 }
 
@@ -165,51 +171,51 @@ fn test_apply() {
 fn test_assign1() {
     let ans = Expr::Then(
         Expr::Assign(
-            Expr::Var("hoge".to_symbol()).into_id(0..4),
-            Expr::Var("fuga".to_symbol()).into_id(7..11),
+            Expr::Var("hoge".to_symbol()).into_id(loc(0..4)),
+            Expr::Var("fuga".to_symbol()).into_id(loc(7..11)),
         )
-        .into_id(0..11),
+        .into_id(loc(0..11)),
         None,
     )
-    .into_id(0..11);
+    .into_id(loc(0..11));
     test_string!("hoge = fuga", ans);
 }
 #[test]
 fn test_assign2() {
     let ans = Expr::Then(
         Expr::Assign(
-            Expr::Var("hoge".to_symbol()).into_id(0..4),
-            Expr::Var("fuga".to_symbol()).into_id(7..11),
+            Expr::Var("hoge".to_symbol()).into_id(loc(0..4)),
+            Expr::Var("fuga".to_symbol()).into_id(loc(7..11)),
         )
-        .into_id(0..11),
-        Some(Expr::Literal(Literal::Float("100.0".to_symbol())).into_id(13..18)),
+        .into_id(loc(0..11)),
+        Some(Expr::Literal(Literal::Float("100.0".to_symbol())).into_id(loc(13..18))),
     )
-    .into_id(0..18);
+    .into_id(loc(0..18));
     test_string!("hoge = fuga\n 100.0", ans);
 }
 #[test]
 fn test_applynested() {
     let ans = Expr::Apply(
-        Expr::Var("myfun".to_symbol()).into_id(0..5),
+        Expr::Var("myfun".to_symbol()).into_id(loc(0..5)),
         vec![Expr::Apply(
-            Expr::Var("myfun2".to_symbol()).into_id(6..12),
-            vec![Expr::Var("callee".to_symbol()).into_id(13..19)],
+            Expr::Var("myfun2".to_symbol()).into_id(loc(6..12)),
+            vec![Expr::Var("callee".to_symbol()).into_id(loc(13..19))],
         )
-        .into_id(6..20)],
+        .into_id(loc(6..20))],
     )
-    .into_id(0..20);
+    .into_id(loc(0..20));
     test_string!("myfun(myfun2(callee))", ans);
 }
 #[test]
 fn test_macroexpand() {
     let ans = Expr::Escape(
         Expr::Apply(
-            Expr::Var("myfun".to_symbol()).into_id(0..6),
-            vec![Expr::Var("callee".to_symbol()).into_id(7..13)],
+            Expr::Var("myfun".to_symbol()).into_id(loc(0..6)),
+            vec![Expr::Var("callee".to_symbol()).into_id(loc(7..13))],
         )
-        .into_id(0..14),
+        .into_id(loc(0..14)),
     )
-    .into_id(0..14);
+    .into_id(loc(0..14));
     test_string!("myfun!(callee)", ans);
 }
 
@@ -219,13 +225,13 @@ fn test_fndef() {
         TypedId {
             ty: Type::Function(
                 vec![
-                    Type::Unknown.into_id_with_span(0..28),
-                    Type::Unknown.into_id_with_span(0..28),
+                    Type::Unknown.into_id_with_location(loc(0..28)),
+                    Type::Unknown.into_id_with_location(loc(0..28)),
                 ],
-                Type::Unknown.into_id_with_span(0..28),
+                Type::Unknown.into_id_with_location(loc(0..28)),
                 None,
             )
-            .into_id_with_span(0..28),
+            .into_id_with_location(loc(0..28)),
 
             id: "hoge".to_symbol(),
         },
@@ -233,20 +239,20 @@ fn test_fndef() {
             vec![
                 TypedId {
                     id: "input".to_symbol(),
-                    ty: Type::Unknown.into_id_with_span(8..13),
+                    ty: Type::Unknown.into_id_with_location(loc(8..13)),
                 },
                 TypedId {
                     id: "gue".to_symbol(),
-                    ty: Type::Unknown.into_id_with_span(14..17),
+                    ty: Type::Unknown.into_id_with_location(loc(14..17)),
                 },
             ],
             None,
-            Expr::Var("input".to_symbol()).into_id(21..26),
+            Expr::Var("input".to_symbol()).into_id(loc(21..26)),
         )
-        .into_id(0..28),
+        .into_id(loc(0..28)),
         None,
     )
-    .into_id(0..28);
+    .into_id(loc(0..28));
     test_string!("fn hoge(input,gue){\n input\n}", ans);
 }
 #[test]
@@ -256,64 +262,64 @@ fn global_fnmultiple() {
             id: "hoge".to_symbol(),
             ty: Type::Function(
                 vec![
-                    Type::Unknown.into_id_with_span(0..28),
-                    Type::Unknown.into_id_with_span(0..28),
+                    Type::Unknown.into_id_with_location(loc(0..28)),
+                    Type::Unknown.into_id_with_location(loc(0..28)),
                 ],
-                Type::Unknown.into_id_with_span(0..28),
+                Type::Unknown.into_id_with_location(loc(0..28)),
                 None,
             )
-            .into_id_with_span(0..28),
+            .into_id_with_location(loc(0..28)),
         },
         Expr::Lambda(
             vec![
                 TypedId {
                     id: "input".to_symbol(),
-                    ty: Type::Unknown.into_id_with_span(8..13),
+                    ty: Type::Unknown.into_id_with_location(loc(8..13)),
                 },
                 TypedId {
                     id: "gue".to_symbol(),
-                    ty: Type::Unknown.into_id_with_span(14..17),
+                    ty: Type::Unknown.into_id_with_location(loc(14..17)),
                 },
             ],
             None,
-            Expr::Var("input".to_symbol()).into_id(21..26),
+            Expr::Var("input".to_symbol()).into_id(loc(21..26)),
         )
-        .into_id(0..28),
+        .into_id(loc(0..28)),
         Some(
             Expr::LetRec(
                 TypedId {
                     id: "hoge".to_symbol(),
                     ty: Type::Function(
                         vec![
-                            Type::Unknown.into_id_with_span(29..57),
-                            Type::Unknown.into_id_with_span(29..57),
+                            Type::Unknown.into_id_with_location(loc(29..57)),
+                            Type::Unknown.into_id_with_location(loc(29..57)),
                         ],
-                        Type::Unknown.into_id_with_span(29..57),
+                        Type::Unknown.into_id_with_location(loc(29..57)),
                         None,
                     )
-                    .into_id_with_span(29..57),
+                    .into_id_with_location(loc(29..57)),
                 },
                 Expr::Lambda(
                     vec![
                         TypedId {
                             id: "input".to_symbol(),
-                            ty: Type::Unknown.into_id_with_span(37..42),
+                            ty: Type::Unknown.into_id_with_location(loc(37..42)),
                         },
                         TypedId {
                             id: "gue".to_symbol(),
-                            ty: Type::Unknown.into_id_with_span(43..46),
+                            ty: Type::Unknown.into_id_with_location(loc(43..46)),
                         },
                     ],
                     None,
-                    Expr::Var("input".to_symbol()).into_id(50..55),
+                    Expr::Var("input".to_symbol()).into_id(loc(50..55)),
                 )
-                .into_id(29..57),
+                .into_id(loc(29..57)),
                 None,
             )
-            .into_id(29..57),
+            .into_id(loc(29..57)),
         ),
     )
-    .into_id(0..57);
+    .into_id(loc(0..57));
     test_string!(
         "fn hoge(input,gue){\n input\n}\nfn hoge(input,gue){\n input\n}",
         ans
@@ -325,45 +331,45 @@ fn test_macrodef() {
     let ans = Expr::LetRec(
         TypedId {
             id: "hoge".to_symbol(),
-            ty: Type::Unknown.into_id_with_span(6..10),
+            ty: Type::Unknown.into_id_with_location(loc(6..10)),
         },
         Expr::Lambda(
             vec![
                 TypedId {
                     id: "input".to_symbol(),
-                    ty: Type::Unknown.into_id_with_span(11..16),
+                    ty: Type::Unknown.into_id_with_location(loc(11..16)),
                 },
                 TypedId {
                     id: "gue".to_symbol(),
-                    ty: Type::Unknown.into_id_with_span(17..20),
+                    ty: Type::Unknown.into_id_with_location(loc(17..20)),
                 },
             ],
             None,
-            Expr::Bracket(Expr::Var("input".to_symbol()).into_id(24..29)).into_id(0..31),
+            Expr::Bracket(Expr::Var("input".to_symbol()).into_id(loc(24..29))).into_id(loc(0..31)),
         )
-        .into_id(0..31),
+        .into_id(loc(0..31)),
         None,
     )
-    .into_id(0..31);
+    .into_id(loc(0..31));
     test_string!("macro hoge(input,gue){\n input\n}", ans);
 }
 
 #[test]
 fn test_tuple() {
     let tuple_items = vec![
-        Expr::Literal(Literal::Float("1.0".to_symbol())).into_id(1..4),
-        Expr::Literal(Literal::Float("2.0".to_symbol())).into_id(6..9),
+        Expr::Literal(Literal::Float("1.0".to_symbol())).into_id(loc(1..4)),
+        Expr::Literal(Literal::Float("2.0".to_symbol())).into_id(loc(6..9)),
     ];
 
-    let ans = Expr::Tuple(tuple_items.clone()).into_id(0..10);
+    let ans = Expr::Tuple(tuple_items.clone()).into_id(loc(0..10));
     test_string!("(1.0, 2.0)", ans);
 
     // with trailing comma
-    let ans = Expr::Tuple(tuple_items.clone()).into_id(0..12);
+    let ans = Expr::Tuple(tuple_items.clone()).into_id(loc(0..12));
     test_string!("(1.0, 2.0, )", ans);
 
     // trailing comma is mandatory for a single-element tuple
-    let ans = Expr::Tuple(vec![tuple_items[0]]).into_id(0..7);
+    let ans = Expr::Tuple(vec![tuple_items[0]]).into_id(loc(0..7));
     test_string!("(1.0, )", ans);
 
     // This is not a tuple
@@ -377,49 +383,49 @@ fn test_stmt_without_return() {
         TypedId {
             id: "test".to_symbol(),
             ty: Type::Function(
-                vec![Type::Unknown.into_id_with_span(0..56)],
-                Type::Unknown.into_id_with_span(0..56),
+                vec![Type::Unknown.into_id_with_location(loc(0..56))],
+                Type::Unknown.into_id_with_location(loc(0..56)),
                 None,
             )
-            .into_id_with_span(0..56),
+            .into_id_with_location(loc(0..56)),
         },
         Expr::Lambda(
             vec![TypedId {
                 id: "input".to_symbol(),
-                ty: Type::Unknown.into_id_with_span(8..13),
+                ty: Type::Unknown.into_id_with_location(loc(8..13)),
             }],
             None,
             Expr::Let(
                 TypedPattern {
                     pat: Pattern::Single("v".to_symbol()),
-                    ty: Type::Unknown.into_id_with_span(24..25),
+                    ty: Type::Unknown.into_id_with_location(loc(24..25)),
                 },
                 Expr::Apply(
-                    Expr::Var("add".to_symbol()).into_id(33..34),
+                    Expr::Var("add".to_symbol()).into_id(loc(33..34)),
                     vec![
-                        Expr::Var("input".to_symbol()).into_id(28..33),
-                        Expr::Literal(Literal::Float("1".to_symbol())).into_id(34..35),
+                        Expr::Var("input".to_symbol()).into_id(loc(28..33)),
+                        Expr::Literal(Literal::Float("1".to_symbol())).into_id(loc(34..35)),
                     ],
                 )
-                .into_id(28..35),
+                .into_id(loc(28..35)),
                 Some(
                     Expr::Then(
                         Expr::Apply(
-                            Expr::Var("print".to_symbol()).into_id(40..45),
-                            vec![Expr::Var("v".to_symbol()).into_id(46..47)],
+                            Expr::Var("print".to_symbol()).into_id(loc(40..45)),
+                            vec![Expr::Var("v".to_symbol()).into_id(loc(46..47))],
                         )
-                        .into_id(40..48),
-                        Some(Expr::Var("v".to_symbol()).into_id(53..54)),
+                        .into_id(loc(40..48)),
+                        Some(Expr::Var("v".to_symbol()).into_id(loc(53..54))),
                     )
-                    .into_id(40..54),
+                    .into_id(loc(40..54)),
                 ),
             )
-            .into_id(20..54),
+            .into_id(loc(20..54)),
         )
-        .into_id(0..56),
+        .into_id(loc(0..56)),
         None,
     )
-    .into_id(0..56);
+    .into_id(loc(0..56));
     test_string!(
         r"fn test(input){
     let v = input+1
@@ -451,8 +457,10 @@ fn test_err_builtin_redefine() {
     let res = &parse(&src.to_string(), None).expect_err("should be error");
     assert_eq!(res.len(), 1);
 
-    let err_ans: Box<dyn ReportableError> = Box::new(error::ParseError::<Token>(
-        Simple::custom(3..6, "Builtin functions cannot be re-defined.").with_label("function decl"),
-    ));
+    let err_ans: Box<dyn ReportableError> = Box::new(error::ParseError::<Token> {
+        content: Simple::custom(3..6, "Builtin functions cannot be re-defined.")
+            .with_label("function decl"),
+        file: "/".to_symbol(),
+    });
     assert_eq!(res[0].to_string(), err_ans.to_string())
 }

--- a/mimium-lang/src/compiler/parser/test.rs
+++ b/mimium-lang/src/compiler/parser/test.rs
@@ -15,7 +15,7 @@ macro_rules! test_string {
                 $ans
             );
         } else {
-            utils::error::report(&srcstr, PathBuf::new(), &errs);
+            utils::error::report(&srcstr, "".to_symbol(), &errs);
             panic!();
         }
     };

--- a/mimium-lang/src/compiler/typing.rs
+++ b/mimium-lang/src/compiler/typing.rs
@@ -453,7 +453,7 @@ impl InferContext {
         body: (TypeNodeId, Location),
     ) -> Result<TypeNodeId, Vec<Error>> {
         let (TypedPattern { pat, ty }, loc_p) = pat;
-        let (t, _loc_b) = body.clone();
+        let (t, loc_b) = body.clone();
         let pat_t = match pat {
             Pattern::Single(id) => {
                 let gt = self.generalize(t);
@@ -480,7 +480,7 @@ impl InferContext {
             }
         }?;
         let ty = self.convert_unknown_to_intermediate(ty);
-        let t2 = Self::unify_types((ty, loc_p.clone()), (pat_t, loc_p.clone()))?;
+        let t2 = Self::unify_types((ty, loc_b.clone()), (pat_t, loc_p.clone()))?;
         Self::unify_types((t2, loc_p), body)
     }
 

--- a/mimium-lang/src/compiler/typing.rs
+++ b/mimium-lang/src/compiler/typing.rs
@@ -335,6 +335,8 @@ impl InferContext {
         let t1r = t1.get_root();
         let t2r = t2.get_root();
         match &(t1r.to_type(), t2r.to_type()) {
+            (Type::Intermediate(i1), Type::Intermediate(i2)) if i1 == i2 => Ok(t1),
+
             (Type::Intermediate(i1), Type::Intermediate(i2)) => {
                 let tv1 = &mut i1.borrow_mut() as &mut TypeVar;
                 if Self::occur_check(tv1.var, t2) {
@@ -669,10 +671,7 @@ impl InferContext {
     }
 }
 
-pub fn infer_root(
-    e: ExprNodeId,
-    builtin_types: &[(Symbol, TypeNodeId)],
-) -> InferContext {
+pub fn infer_root(e: ExprNodeId, builtin_types: &[(Symbol, TypeNodeId)]) -> InferContext {
     let mut ctx = InferContext::new(builtin_types);
     let _t = ctx.infer_type(e).unwrap_or(Type::Failure.into_id());
     ctx.substitute_all_intermediates();

--- a/mimium-lang/src/compiler/typing.rs
+++ b/mimium-lang/src/compiler/typing.rs
@@ -80,6 +80,11 @@ impl ReportableError for Error {
     }
 }
 
+pub struct InferResult {
+    ty: TypeNodeId,
+    errs: Vec<Error>,
+}
+
 #[derive(Clone, Debug, PartialEq)]
 pub struct InferContext {
     interm_idx: u64,
@@ -90,7 +95,7 @@ pub struct InferContext {
     generalize_map: BTreeMap<u64, u64>,
     instantiate_map: BTreeMap<u64, u64>,
     result_map: BTreeMap<ExprKey, TypeNodeId>,
-    pub env: Environment<TypeNodeId>, // interm_map:HashMap<i64,Type>
+    pub env: Environment<TypeNodeId>,
 }
 impl InferContext {
     fn new(builtins: &[(Symbol, TypeNodeId)]) -> Self {

--- a/mimium-lang/src/compiler/typing.rs
+++ b/mimium-lang/src/compiler/typing.rs
@@ -125,7 +125,7 @@ pub struct InferContext {
     instantiate_map: BTreeMap<u64, u64>,
     result_map: BTreeMap<ExprKey, TypeNodeId>,
     pub env: Environment<TypeNodeId>,
-    errors: Vec<Error>,
+    pub errors: Vec<Error>,
 }
 impl InferContext {
     fn new(builtins: &[(Symbol, TypeNodeId)]) -> Self {

--- a/mimium-lang/src/compiler/typing.rs
+++ b/mimium-lang/src/compiler/typing.rs
@@ -594,8 +594,8 @@ impl InferContext {
                     span: body.to_span(),
                     path: self.file_path,
                 };
-                let _ = self.bind_pattern((tpat.clone(), loc_p), (bodyt, loc_b))?;
-
+                let pat_t = self.bind_pattern((tpat.clone(), loc_p), (bodyt, loc_b));
+                let _pat_t = self.unwrap_result(pat_t);
                 match then {
                     Some(e) => self.infer_type(*e),
                     None => Ok(Type::Primitive(PType::Unit).into_id()),

--- a/mimium-lang/src/interner.rs
+++ b/mimium-lang/src/interner.rs
@@ -159,7 +159,7 @@ impl ExprNodeId {
 
     pub fn to_span(&self) -> Span {
         with_session_globals(|session_globals| match session_globals.get_span(*self) {
-            Some(span) => span.clone(),
+            Some(loc) => loc.span.clone(),
             None => dummy_span!(),
         })
     }
@@ -172,7 +172,7 @@ impl TypeNodeId {
 
     pub fn to_span(&self) -> Span {
         with_session_globals(|session_globals| match session_globals.get_span(*self) {
-            Some(span) => span.clone(),
+            Some(loc) => loc.span.clone(),
             None => dummy_span!(),
         })
     }

--- a/mimium-lang/src/mir.rs
+++ b/mimium-lang/src/mir.rs
@@ -123,6 +123,7 @@ pub enum Instruction {
     CastFtoI(VPtr),
     CastItoF(VPtr),
     CastItoB(VPtr),
+    Error,
 }
 
 #[derive(Debug, Default, Clone, PartialEq)]

--- a/mimium-lang/src/mir.rs
+++ b/mimium-lang/src/mir.rs
@@ -200,3 +200,12 @@ pub struct Mir {
     pub functions: Vec<Function>,
     pub file_path: Option<Symbol>,
 }
+
+impl Mir {
+    pub fn new(file_path: Option<Symbol>) -> Self {
+        Self {
+            file_path,
+            ..Default::default()
+        }
+    }
+}

--- a/mimium-lang/src/mir/print.rs
+++ b/mimium-lang/src/mir/print.rs
@@ -187,6 +187,7 @@ impl std::fmt::Display for Instruction {
             Instruction::CastFtoI(_) => todo!(),
             Instruction::CastItoF(_) => todo!(),
             Instruction::CastItoB(_) => todo!(),
+            Instruction::Error => write!(f, "error"),
         }
     }
 }

--- a/mimium-lang/src/repl.rs
+++ b/mimium-lang/src/repl.rs
@@ -1,8 +1,5 @@
 use crate::{
-    ast_interpreter::{self, PValue, Value},
-    compiler::{self, interpret_top},
-    utils::error,
-    utils::miniprint::MiniPrint,
+    ast_interpreter::{self, PValue, Value}, compiler::{self, interpret_top}, interner::ToSymbol, utils::{error, miniprint::MiniPrint}
 };
 use std::{
     io::{stdin, stdout, Write},
@@ -67,7 +64,7 @@ fn repl(data: &mut ReplAppData) -> ! {
                         Ok(v) => {
                             println!("{:?}", v);
                         }
-                        Err(e) => error::report(&src, PathBuf::new(), &e),
+                        Err(e) => error::report(&src, "".to_symbol(), &e),
                     },
                     ReplMode::EvalMulti(n) => {
                         let mut res = Ok(Value::Primitive(PValue::Numeric(0.0)));
@@ -79,14 +76,14 @@ fn repl(data: &mut ReplAppData) -> ! {
                             Ok(v) => {
                                 println!("{:?}", v);
                             }
-                            Err(e) => error::report(&src, PathBuf::new(), &e),
+                            Err(e) => error::report(&src, "".to_symbol(), &e),
                         }
                     }
                     ReplMode::ShowAST => match compiler::emit_ast(&src, None) {
                         Ok(ast) => {
                             println!("{}", ast.pretty_print());
                         }
-                        Err(e) => error::report(&src, PathBuf::new(), &e),
+                        Err(e) => error::report(&src, "".to_symbol(), &e),
                     },
                 }
                 src.clear();

--- a/mimium-lang/src/runtime.rs
+++ b/mimium-lang/src/runtime.rs
@@ -1,4 +1,4 @@
-use crate::utils::{error::ReportableError, metadata::Span};
+use crate::utils::{error::ReportableError, metadata::{Location, Span}};
 
 // pub mod scheduler;
 // pub mod hir_interpreter;
@@ -21,7 +21,7 @@ impl std::fmt::Display for ErrorKind {
     }
 }
 #[derive(Debug)]
-pub struct Error(pub ErrorKind, pub Span);
+pub struct Error(pub ErrorKind, pub Location);
 impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let _ = write!(f, "Runtime Error: ");
@@ -32,7 +32,7 @@ impl std::fmt::Display for Error {
 impl std::error::Error for Error {}
 
 impl ReportableError for Error {
-    fn get_span(&self) -> std::ops::Range<usize> {
-        self.1.clone()
+    fn get_labels(&self) -> Vec<(crate::utils::metadata::Location, String)> {
+        vec![(self.1.clone(),self.0.to_string())]
     }
 }

--- a/mimium-lang/src/types.rs
+++ b/mimium-lang/src/types.rs
@@ -86,8 +86,8 @@ impl Type {
         with_session_globals(|session_globals| session_globals.store_type(self))
     }
 
-    pub fn into_id_with_span(self, span: Location) -> TypeNodeId {
-        with_session_globals(|session_globals| session_globals.store_type_with_span(self, span))
+    pub fn into_id_with_location(self, loc: Location) -> TypeNodeId {
+        with_session_globals(|session_globals| session_globals.store_type_with_location(self, loc))
     }
 
     pub fn to_string_for_error(&self) -> String {

--- a/mimium-lang/src/types.rs
+++ b/mimium-lang/src/types.rs
@@ -46,6 +46,8 @@ pub enum Type {
     Intermediate(Rc<RefCell<TypeVar>>),
     TypeScheme(u64),
     Instantiated(u64),
+    /// Failure type: it is bottom type that can be unified to any type and return bottom type.
+    Failure,
     Unknown,
 }
 
@@ -231,6 +233,7 @@ impl fmt::Display for Type {
             Type::Instantiated(id) => {
                 write!(f, "'{id}")
             }
+            Type::Failure => write!(f, "!"),
             Type::Unknown => write!(f, "unknown"),
         }
     }

--- a/mimium-lang/src/types.rs
+++ b/mimium-lang/src/types.rs
@@ -3,7 +3,7 @@ use std::{cell::RefCell, fmt, rc::Rc};
 use crate::{
     format_vec,
     interner::{with_session_globals, Symbol, TypeNodeId},
-    utils::metadata::Span,
+    utils::metadata::Location,
 };
 
 /// Basic types that are not boxed.
@@ -86,7 +86,7 @@ impl Type {
         with_session_globals(|session_globals| session_globals.store_type(self))
     }
 
-    pub fn into_id_with_span(self, span: Span) -> TypeNodeId {
+    pub fn into_id_with_span(self, span: Location) -> TypeNodeId {
         with_session_globals(|session_globals| session_globals.store_type_with_span(self, span))
     }
 

--- a/mimium-lang/src/utils/environment.rs
+++ b/mimium-lang/src/utils/environment.rs
@@ -16,6 +16,11 @@ pub enum LookupRes<T: Clone> {
     Global(T),
     None,
 }
+impl<T:Clone> Default for Environment<T>{
+    fn default() -> Self {
+        Self(EnvInner::new())
+    }
+}
 impl<T: Clone> Environment<T> {
     pub fn new() -> Self {
         Self(EnvInner::new())

--- a/mimium-lang/src/utils/error.rs
+++ b/mimium-lang/src/utils/error.rs
@@ -2,9 +2,8 @@ use ariadne::{Color, ColorGenerator, Label, Report, ReportKind, Source};
 use std::path;
 
 pub trait ReportableError: std::error::Error {
-    /// message is used for reporting verbose message for ariadne.
-    ///
     fn get_span(&self) -> std::ops::Range<usize>;
+    /// message is used for reporting verbose message for ariadne.
     fn get_message(&self, _color: Color) -> String {
         self.to_string()
     }
@@ -31,7 +30,7 @@ impl ReportableError for ReportableErrorDyn {
     }
 }
 
-pub fn report<T>(src: &String, srcpath: T, errs: &Vec<Box<dyn ReportableError>>)
+pub fn report<T>(src: &String, srcpath: T, errs: &[Box<dyn ReportableError>])
 where
     T: AsRef<path::Path>,
 {
@@ -52,7 +51,7 @@ where
     }
 }
 
-pub fn dump_to_string(errs: &Vec<Box<dyn ReportableError>>) -> String {
+pub fn dump_to_string(errs: &[Box<dyn ReportableError>]) -> String {
     let mut res = String::new();
     for e in errs {
         res += e.get_message(Color::Green).as_str();

--- a/mimium-lang/src/utils/error.rs
+++ b/mimium-lang/src/utils/error.rs
@@ -1,6 +1,8 @@
 use ariadne::{ColorGenerator, Label, Report, ReportKind, Source};
 use std::path;
 
+use crate::interner::ToSymbol;
+
 use super::metadata::Location;
 
 pub trait ReportableError: std::error::Error {
@@ -43,12 +45,12 @@ where
                 .with_message(message)
                 .with_color(colors.next())
         });
-        let builder = Report::build(ReportKind::Error, path.to_string(), 4)
+        let builder = Report::build(ReportKind::Error, path.to_symbol(), 4)
             .with_message(e.get_message())
             .with_labels(labels)
             .finish();
         builder
-            .eprint((path.to_string(), Source::from(src)))
+            .eprint((path.to_symbol(), Source::from(src)))
             .unwrap();
     }
 }

--- a/mimium-lang/src/utils/metadata.rs
+++ b/mimium-lang/src/utils/metadata.rs
@@ -1,16 +1,23 @@
 use crate::interner::{Symbol, ToSymbol};
 
-
 pub type Span = std::ops::Range<usize>;
 
-#[derive(Clone,Debug)]
+#[derive(Clone, Debug)]
 pub struct Location {
     pub span: Span,
     pub path: Symbol,
 }
-impl Default for Location{
+impl Location {
+    pub fn new(span: Span, path: Symbol) -> Self {
+        Self { span, path }
+    }
+}
+impl Default for Location {
     fn default() -> Self {
-        Self { span: 0..0, path: "".to_symbol() }
+        Self {
+            span: 0..0,
+            path: "".to_symbol(),
+        }
     }
 }
 

--- a/mimium-lang/src/utils/metadata.rs
+++ b/mimium-lang/src/utils/metadata.rs
@@ -1,4 +1,25 @@
-pub type Span = std::ops::Range<usize>;
+use crate::interner::{Symbol, ToSymbol};
+
+#[derive(Clone,Debug)]
+pub struct Location {
+    span: std::ops::Range<usize>,
+    path: String,
+}
+impl ariadne::Span for Location {
+    type SourceId = String;
+
+    fn source(&self) -> &Self::SourceId {
+        &self.path
+    }
+
+    fn start(&self) -> usize {
+        self.span.start
+    }
+
+    fn end(&self) -> usize {
+        self.span.end
+    }
+}
 
 // #[derive(Clone, Debug, PartialEq)]
 // pub struct WithMeta<T>{

--- a/mimium-lang/src/utils/metadata.rs
+++ b/mimium-lang/src/utils/metadata.rs
@@ -1,12 +1,15 @@
 use crate::interner::{Symbol, ToSymbol};
 
+
+pub type Span = std::ops::Range<usize>;
+
 #[derive(Clone,Debug)]
 pub struct Location {
-    span: std::ops::Range<usize>,
-    path: String,
+    pub span: Span,
+    pub path: Symbol,
 }
 impl ariadne::Span for Location {
-    type SourceId = String;
+    type SourceId = Symbol;
 
     fn source(&self) -> &Self::SourceId {
         &self.path

--- a/mimium-lang/src/utils/metadata.rs
+++ b/mimium-lang/src/utils/metadata.rs
@@ -2,7 +2,7 @@ use crate::interner::{Symbol, ToSymbol};
 
 pub type Span = std::ops::Range<usize>;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Location {
     pub span: Span,
     pub path: Symbol,

--- a/mimium-lang/src/utils/metadata.rs
+++ b/mimium-lang/src/utils/metadata.rs
@@ -8,6 +8,12 @@ pub struct Location {
     pub span: Span,
     pub path: Symbol,
 }
+impl Default for Location{
+    fn default() -> Self {
+        Self { span: 0..0, path: "".to_symbol() }
+    }
+}
+
 impl ariadne::Span for Location {
     type SourceId = Symbol;
 

--- a/mimium-symphonia/tests/integration_test.rs
+++ b/mimium-symphonia/tests/integration_test.rs
@@ -2,7 +2,7 @@ use mimium_lang::plugin::Plugin;
 use mimium_symphonia::SamplerPlugin;
 use mimium_test::*;
 
-fn run_file_with_symphonia(path: &str, times: u64) -> Result<Vec<f64>, ()> {
+fn run_file_with_symphonia(path: &str, times: u64) -> Option<Vec<f64>> {
     let plugins: [Box<dyn Plugin>; 1] = [Box::new(SamplerPlugin)];
     run_file_with_plugins(path, times, plugins.into_iter(), false)
 }

--- a/mimium-test/src/lib.rs
+++ b/mimium-test/src/lib.rs
@@ -130,6 +130,18 @@ pub fn run_file_test(path: &str, times: u64, stereo: bool) -> Option<Vec<f64>> {
     }
 }
 
+pub fn run_error_test(path: &str, stereo: bool) -> Vec<Box<dyn ReportableError>> {
+    let (file, src) = load_src(path);
+    let path_sym = file.to_string_lossy().to_symbol();
+    let res = run_source_test(&src, 1, stereo, Some(path_sym));
+    match res {
+        Ok(_res) => {
+            panic!("this test should emit errors")
+        }
+        Err(errs) => errs,
+    }
+}
+
 pub fn load_src(path: &str) -> (PathBuf, String) {
     let crate_root = std::env::var("TEST_ROOT").expect(
         r#"You must set TEST_ROOT environment variable to run test.

--- a/mimium-test/src/lib.rs
+++ b/mimium-test/src/lib.rs
@@ -8,7 +8,8 @@ use mimium_lang::{
     runtime::{self, vm},
     utils::{
         error::{report, ReportableError},
-        fileloader, metadata::Location,
+        fileloader,
+        metadata::Location,
     },
     ExecContext,
 };
@@ -23,7 +24,7 @@ pub fn run_bytecode_test(
     } else {
         Err(vec![Box::new(runtime::Error(
             runtime::ErrorKind::Unknown,
-            Location::default()
+            Location::default(),
         ))])
     }
 }
@@ -108,7 +109,7 @@ pub fn run_file_with_plugins(
     match res {
         Ok(res) => Some(res),
         Err(errs) => {
-            report(&src, file, &errs);
+            report(&src, file.to_string_lossy().to_symbol(), &errs);
             None
         }
     }
@@ -123,7 +124,7 @@ pub fn run_file_test(path: &str, times: u64, stereo: bool) -> Option<Vec<f64>> {
     match res {
         Ok(res) => Some(res),
         Err(errs) => {
-            report(&src, file, &errs);
+            report(&src, path_sym, &errs);
             None
         }
     }

--- a/mimium-test/tests/intergration_test.rs
+++ b/mimium-test/tests/intergration_test.rs
@@ -1,6 +1,5 @@
 use mimium_lang::{interner::ToSymbol, utils::error::report};
 use mimium_test::*;
-use std::path::Path;
 
 fn run_simple_test(expr: &str, expect: f64, times: u64) {
     let src = format!(
@@ -337,4 +336,12 @@ fn if_state() {
         9.0, 0.0,
     ];
     assert_eq!(res, ans);
+}
+
+#[test]
+
+fn many_errors() {
+    let res = run_error_test("many_errors.mmm", false);
+    //todo! check error types
+    assert_eq!(res.len(), 6);
 }

--- a/mimium-test/tests/intergration_test.rs
+++ b/mimium-test/tests/intergration_test.rs
@@ -1,4 +1,4 @@
-use mimium_lang::utils::error::report;
+use mimium_lang::{interner::ToSymbol, utils::error::report};
 use mimium_test::*;
 use std::path::Path;
 
@@ -18,7 +18,7 @@ fn dsp(){{
             assert_eq!(res, ans, "expr: {expr}");
         }
         Err(errs) => {
-            report(&src, Path::new("(from template)"), &errs);
+            report(&src, "(from template)".to_symbol(), &errs);
             panic!("invalid syntax");
         }
     }
@@ -303,11 +303,9 @@ fn fb_mem3_state_size() {
 }
 
 #[test]
-fn fb_and_stateful_call(){
+fn fb_and_stateful_call() {
     let res = run_file_test_mono("fb_and_stateful_call.mmm", 10).unwrap();
-    let ans = vec![
-        0.0, 0.0, 1.0, 3.0, 6.0, 10.0, 15.0, 21.0, 28.0, 36.0
-    ];
+    let ans = vec![0.0, 0.0, 1.0, 3.0, 6.0, 10.0, 15.0, 21.0, 28.0, 36.0];
     assert_eq!(res, ans);
 }
 

--- a/mimium-test/tests/mmm/closure_counter_tuple.mmm
+++ b/mimium-test/tests/mmm/closure_counter_tuple.mmm
@@ -15,7 +15,7 @@ fn makecounter(){
     }
     (countup,0.0,countdown)
 }
-let (c1,_,c2) = makecounter()
+let (c1,_x,c2) = makecounter()
 fn dsp(){
     (c1(),c2())
 }

--- a/mimium-test/tests/mmm/many_errors.mmm
+++ b/mimium-test/tests/mmm/many_errors.mmm
@@ -1,0 +1,22 @@
+fn parse_error_continue(){
+    1+ +- ab |>
+}
+
+fn type_error_continue(){
+    let a:string = 1.0
+    let str = "test"
+    let mismatch = str + 2.0
+    let nonapplicable = str(100.0)
+    let (a,b) = (1.0,2.0,3.0)
+    let unknownvar = hogehoge
+    0.0
+}
+
+fn functional_feed (x){
+    let s = self
+    |x| { s(x) }
+}
+
+fn dsp(){
+    0.0
+}


### PR DESCRIPTION
This is WIP experimental branch of the type checker implementation and error definition.

- [x] Refactoring `ReportableError` trait. Allowing multiple spans in the single error to report type mismatch error correctly.
- [x] Implement "Failure" type(=so called "Bottom" type in the type theorem), that can be unified to any types to implement recoverable type checking.

This is also a necessary step toward implementing language server...