### PR TITLE
 mimalloc as global allocator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1238,6 +1238,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23aa6811d3bd4deb8a84dde645f943476d13b248d818edcf8ce0b2f37f036b44"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1327,6 +1337,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "mimalloc"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68914350ae34959d83f732418d51e2427a794055d0b9529f48259ac07af65633"
+dependencies = [
+ "libmimalloc-sys",
+]
+
+[[package]]
 name = "mimium-audiodriver"
 version = "2.0.0-alpha-1"
 dependencies = [
@@ -1371,6 +1390,7 @@ dependencies = [
  "half",
  "itertools 0.13.0",
  "log",
+ "mimalloc",
  "slotmap",
  "string-interner",
 ]

--- a/mimium-lang/Cargo.toml
+++ b/mimium-lang/Cargo.toml
@@ -7,6 +7,10 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 # [lib]
 
+[features]
+default = ["mimalloc"]
+mimalloc = ["dep:mimalloc"]
+
 
 [dependencies]
 
@@ -18,3 +22,4 @@ slotmap = "1.0.7"
 colog = "1.3.0"
 half = "2.4.1"
 itertools = "0.13.0"
+mimalloc = { version = "0.1.43", optional = true }

--- a/mimium-lang/benches/bench.rs
+++ b/mimium-lang/benches/bench.rs
@@ -45,33 +45,65 @@ fn dsp(){{
             )
         }
 
-        fn bench_multiosc(b: &mut Bencher, n: usize) {
-            let content = make_multiosc_src(n);
-            let compiler = compiler::Context::new([].into_iter(), None);
-            let program = compiler.emit_bytecode(&content).expect("ok");
+        fn bench_runtime(b: &mut Bencher, content: &str, times: usize) {
+            let compiler = compiler::Context::new([], None);
+            let program = compiler.emit_bytecode(content).expect("ok");
             let idx = program.get_fun_index(&"dsp".to_symbol()).expect("ok");
             let mut machine = Machine::new(program, [].into_iter(), [].into_iter());
             machine.execute_main();
-            b.iter(move || machine.execute_idx(idx));
+            b.iter(move || {
+                for _i in 0..times {
+                    let _ = machine.execute_idx(idx);
+                }
+            });
         }
         #[bench]
         fn bench_multiosc5(b: &mut Bencher) {
-            bench_multiosc(b, 5);
+            bench_runtime(b, &make_multiosc_src(5),1);
         }
         #[bench]
         fn bench_multiosc7(b: &mut Bencher) {
-            bench_multiosc(b, 7);
+            bench_runtime(b, &make_multiosc_src(7),1);
         }
         #[bench]
         fn bench_multiosc10(b: &mut Bencher) {
-            bench_multiosc(b, 10);
+            bench_runtime(b, &make_multiosc_src(9),1);
         }
         #[bench]
         fn bench_multiosc15(b: &mut Bencher) {
-            bench_multiosc(b, 15);
+            bench_runtime(b, &make_multiosc_src(15),1);
+        }
+        fn make_partialapp_src_from_template(c: &str) -> String {
+            format!(
+                "let pi = 3.14159265359
+let sr = 44100.0
+fn phasor(freq,phase){{
+  (self + freq/sr + phase)%1.0
+}}
+fn osc(freq,phase){{
+  sin(phasor(freq,phase)*pi*2.0)
+}}
+fn dsp(){{
+    {c}
+}}"
+            )
+        }
+        fn make_partialapp_src() -> String {
+            make_partialapp_src_from_template("440 |> osc(_,0.0)")
+        }
+        fn make_no_partialapp_src() -> String {
+            make_partialapp_src_from_template("osc(440,0.0)")
+        }
+        //test the performance degradation when open closure is made on `dsp` function with partial application.
+        #[bench]
+        fn bench_partialapp(b: &mut Bencher) {
+            bench_runtime(b, &make_partialapp_src(),10);
+        }
+        #[bench]
+        fn bench_partialapp_no(b: &mut Bencher) {
+            bench_runtime(b, &make_no_partialapp_src(),10);
         }
     }
-
     mod parse {
         use mimium_lang::compiler;
         use test::Bencher;

--- a/mimium-lang/src/lib.rs
+++ b/mimium-lang/src/lib.rs
@@ -23,6 +23,13 @@ use runtime::vm::{
 };
 use utils::error::ReportableError;
 
+#[cfg(feature = "mimalloc")]
+use mimalloc::MiMalloc;
+#[cfg(feature = "mimalloc")]
+#[global_allocator]
+static GLOBAL: MiMalloc = MiMalloc;
+
+
 /// A set of compiler and external functions (plugins).
 /// From this information, user can generate VM with [`Self::prepare_machine`].
 pub struct ExecContext {


### PR DESCRIPTION
This PR adds `mimalloc` by Microsoft as a default memory allocator.

https://docs.rs/mimalloc/latest/mimalloc/

mimalloc is suitable for a VM's allocator as it's initially designed for Koka, it improve performance when the allocation size is small.


before
```
test tests::parse::bench_many_symbols10 ... bench:   8,330,289.60 ns/iter (+/- 545,905.39)
test tests::parse::bench_many_symbols5  ... bench:   2,473,266.70 ns/iter (+/- 62,802.59)
test tests::parse::bench_many_symbols3  ... bench:   1,072,679.20 ns/iter (+/- 40,947.95)
test tests::runtime::bench_multiosc15   ... bench:       5,464.05 ns/iter (+/- 126.53)
test tests::runtime::bench_multiosc10   ... bench:       3,674.98 ns/iter (+/- 1,237.57)
test tests::runtime::bench_multiosc7    ... bench:       2,580.49 ns/iter (+/- 200.76)
test tests::runtime::bench_multiosc5    ... bench:       1,852.25 ns/iter (+/- 49.89)
test tests::scheduler_counter ... bench:     494,956.25 ns/iter (+/- 11,030.16)
```

after
```
test tests::parse::bench_many_symbols10 ... bench:   7,056,516.70 ns/iter (+/- 1,743,678.40)
test tests::parse::bench_many_symbols5  ... bench:   2,043,204.20 ns/iter (+/- 109,519.89)
test tests::parse::bench_many_symbols3  ... bench:     884,628.12 ns/iter (+/- 99,362.72)
test tests::runtime::bench_multiosc15   ... bench:       5,232.11 ns/iter (+/- 73.01)
test tests::runtime::bench_multiosc10   ... bench:       3,506.63 ns/iter (+/- 83.76)
test tests::runtime::bench_multiosc7    ... bench:       2,471.13 ns/iter (+/- 48.06)
test tests::runtime::bench_multiosc5    ... bench:       1,775.10 ns/iter (+/- 32.78)
test tests::scheduler_counter ... bench:     403,322.90 ns/iter (+/- 27,579.60)
```

