### PR TITLE
Do not launch gui when no probe is created

### DIFF
--- a/mimium-guitools/src/lib.rs
+++ b/mimium-guitools/src/lib.rs
@@ -63,25 +63,31 @@ impl GuiToolPlugin {
 }
 impl SystemPlugin for GuiToolPlugin {
     fn try_get_main_loop(&mut self) -> Option<Box<dyn FnOnce()>> {
-        self.window.take().map(|window| -> Box<dyn FnOnce()> {
-            Box::new(move || {
-                let native_options = eframe::NativeOptions {
-                    viewport: egui::ViewportBuilder::default()
-                        .with_inner_size([400.0, 300.0])
-                        .with_min_inner_size([300.0, 220.0]), // .with_icon(
-                    //     // NOTE: Adding an icon is optional
-                    //     eframe::icon_data::from_png_bytes(&include_bytes!("../assets/icon-256.png")[..])
-                    //         .expect("Failed to load icon"),)
-                    ..Default::default()
-                };
-                let _ = eframe::run_native(
-                    "mimium guitools",
-                    native_options,
-                    Box::new(|_cc| Ok(Box::new(window))),
-                )
-                .inspect_err(|e| log::error!("{e}"));
+        let make_window = self.window.as_ref().is_some_and(|w| !w.is_empty());
+
+        make_window
+            .then(|| {
+                self.window.take().map(|window| -> Box<dyn FnOnce()> {
+                    Box::new(move || {
+                        let native_options = eframe::NativeOptions {
+                            viewport: egui::ViewportBuilder::default()
+                                .with_inner_size([400.0, 300.0])
+                                .with_min_inner_size([300.0, 220.0]), // .with_icon(
+                            //     // NOTE: Adding an icon is optional
+                            //     eframe::icon_data::from_png_bytes(&include_bytes!("../assets/icon-256.png")[..])
+                            //         .expect("Failed to load icon"),)
+                            ..Default::default()
+                        };
+                        let _ = eframe::run_native(
+                            "mimium guitools",
+                            native_options,
+                            Box::new(|_cc| Ok(Box::new(window))),
+                        )
+                        .inspect_err(|e| log::error!("{e}"));
+                    })
+                })
             })
-        })
+            .flatten()
     }
     fn gen_interfaces(&self) -> Vec<SysPluginSignature> {
         let ty = function!(vec![string_t!()], Self::get_closure_type());

--- a/mimium-guitools/src/plot_window.rs
+++ b/mimium-guitools/src/plot_window.rs
@@ -31,6 +31,9 @@ impl PlotApp {
             Color32::from_rgba_premultiplied(r, g, b, 200),
         ))
     }
+    pub fn is_empty(&self) -> bool {
+        self.plot.is_empty()
+    }
 }
 
 impl eframe::App for PlotApp {
@@ -55,7 +58,7 @@ impl eframe::App for PlotApp {
                 .legend(Legend::default())
                 .show_axes(true)
                 .show_grid(true)
-                .auto_bounds([true,self.autoscale].into())
+                .auto_bounds([true, self.autoscale].into())
                 .coordinates_formatter(Corner::LeftBottom, CoordinatesFormatter::default());
 
             plot.show(ui, |plot_ui| {


### PR DESCRIPTION
With current implementation, plot gui is always launched whenever probe is created or not.

With this PR, plot gui will not launched unless user call "make_probe" at least once.