### PR TITLE
Add "samplerate" literal

### DIFF
--- a/mimium-audiodriver/src/backends/cpal.rs
+++ b/mimium-audiodriver/src/backends/cpal.rs
@@ -2,6 +2,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
 use crate::driver::{Driver, RuntimeData, SampleRate};
+use crate::runtime_fn;
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 use cpal::{self, BufferSize, StreamConfig};
 use mimium_lang::log;
@@ -22,7 +23,7 @@ pub struct NativeDriver {
 impl NativeDriver {
     pub fn new(buffer_size: usize) -> Self {
         Self {
-            sr: SampleRate(48000),
+            sr: SampleRate::from(48000),
             hardware_ichannels: 1,
             hardware_ochannels: 1,
             is_playing: false,
@@ -164,7 +165,7 @@ impl NativeDriver {
             .next()
             .expect("no supported config");
         sample_rate
-            .and_then(|sr| config_builder.try_with_sample_rate(cpal::SampleRate(sr.0)))
+            .and_then(|sr| config_builder.try_with_sample_rate(cpal::SampleRate(sr.get())))
             .unwrap_or_else(|| {
                 device
                     .default_input_config()
@@ -181,7 +182,7 @@ impl NativeDriver {
             .expect("no supported config");
 
         sample_rate
-            .and_then(|sr| config_builder.try_with_sample_rate(cpal::SampleRate(sr.0)))
+            .and_then(|sr| config_builder.try_with_sample_rate(cpal::SampleRate(sr.get())))
             .unwrap_or_else(|| {
                 config_builder
                     .try_with_sample_rate(cpal::SampleRate(44100))
@@ -205,8 +206,10 @@ impl NativeDriver {
 impl Driver for NativeDriver {
     type Sample = f64;
     fn get_runtimefn_infos(&self) -> Vec<vm::ExtClsInfo> {
-        let getnow = crate::runtime_fn::gen_getnowfn(self.count.clone());
-        vec![getnow]
+        let getnow = runtime_fn::gen_getnowfn(self.count.clone());
+
+        let getsamplerate = runtime_fn::gen_getsampleratefn(self.sr.0.clone());
+        vec![getnow, getsamplerate]
     }
 
     fn init(&mut self, ctx: ExecContext, sample_rate: Option<SampleRate>) -> bool {
@@ -218,7 +221,7 @@ impl Driver for NativeDriver {
 
         let idevice = host.default_input_device();
         let in_stream = if let Some(idevice) = idevice {
-            let mut iconfig = Self::init_iconfig(&idevice, sample_rate);
+            let mut iconfig = Self::init_iconfig(&idevice, sample_rate.clone());
             iconfig.buffer_size = BufferSize::Fixed((self.buffer_size) as u32);
             log::info!(
                 "input device: {} buffer size:{:?}",
@@ -339,8 +342,8 @@ impl Driver for NativeDriver {
         self.is_playing
     }
 
-    fn get_samplerate(&self) -> crate::driver::SampleRate {
-        self.sr
+    fn get_samplerate(&self) -> u32 {
+        self.sr.get()
     }
 
     fn get_current_sample(&self) -> Time {

--- a/mimium-audiodriver/src/backends/cpal.rs
+++ b/mimium-audiodriver/src/backends/cpal.rs
@@ -174,21 +174,26 @@ impl NativeDriver {
             .config()
     }
     fn init_oconfig(device: &cpal::Device, sample_rate: Option<SampleRate>) -> StreamConfig {
-        let config_builder = device
-            .supported_output_configs()
-            .unwrap()
-            //try to find maximum channel setting, because some headphone device returns mono as default config.
-            .max_by(|x, y| x.channels().cmp(&y.channels()))
-            .expect("no supported config");
-
         sample_rate
-            .and_then(|sr| config_builder.try_with_sample_rate(cpal::SampleRate(sr.get())))
-            .unwrap_or_else(|| {
-                config_builder
-                    .try_with_sample_rate(cpal::SampleRate(44100))
-                    .unwrap_or_else(|| config_builder.with_max_sample_rate())
+            .and_then(|sr| {
+                if cfg!(not(target_os = "macos")) {
+                    let config_builder = device
+                        .supported_output_configs()
+                        .unwrap()
+                        .max_by(|x, y| x.cmp_default_heuristics(&y))
+                        .expect("no supported config");
+                    config_builder.try_with_sample_rate(cpal::SampleRate(sr.get()))
+                } else {
+                    // Because the cpal's Device:.supported_output_configs: for CoreAudio is not usable,
+                    // we ignore given samplerate and use default configuration.
+                    // See https://github.com/RustAudio/cpal/pull/96
+                    None
+                }
             })
-            .config()
+            .map_or_else(
+                || device.default_output_config().unwrap().config(),
+                |builder| builder.config(),
+            )
     }
     fn set_streams(
         &mut self,
@@ -207,7 +212,6 @@ impl Driver for NativeDriver {
     type Sample = f64;
     fn get_runtimefn_infos(&self) -> Vec<vm::ExtClsInfo> {
         let getnow = runtime_fn::gen_getnowfn(self.count.clone());
-
         let getsamplerate = runtime_fn::gen_getsampleratefn(self.sr.0.clone());
         vec![getnow, getsamplerate]
     }

--- a/mimium-audiodriver/src/backends/csv.rs
+++ b/mimium-audiodriver/src/backends/csv.rs
@@ -91,7 +91,7 @@ impl Driver for CsvDriver {
         self.driver.pause()
     }
 
-    fn get_samplerate(&self) -> crate::driver::SampleRate {
+    fn get_samplerate(&self) -> u32 {
         self.driver.get_samplerate()
     }
 

--- a/mimium-audiodriver/src/backends/local_buffer.rs
+++ b/mimium-audiodriver/src/backends/local_buffer.rs
@@ -67,7 +67,9 @@ impl Driver for LocalBufferDriver {
 
     fn get_runtimefn_infos(&self) -> Vec<vm::ExtClsInfo> {
         let getnow = crate::runtime_fn::gen_getnowfn(self.count.clone());
-        vec![getnow]
+        let getsamplerate = crate::runtime_fn::gen_getsampleratefn(self.samplerate.0.clone());
+
+        vec![getnow, getsamplerate]
     }
 
     fn init(&mut self, ctx: ExecContext, sample_rate: Option<crate::driver::SampleRate>) -> bool {

--- a/mimium-audiodriver/src/backends/local_buffer.rs
+++ b/mimium-audiodriver/src/backends/local_buffer.rs
@@ -29,7 +29,7 @@ impl Default for LocalBufferDriver {
         Self {
             vmdata: None,
             count,
-            samplerate: SampleRate(48000),
+            samplerate: SampleRate::from(48000),
             localbuffer: vec![],
             times: 0,
             _ichannels: 0,
@@ -45,7 +45,7 @@ impl LocalBufferDriver {
         Self {
             vmdata: None,
             count,
-            samplerate: SampleRate(48000),
+            samplerate: SampleRate::from(48000),
             localbuffer: vec![],
             times,
             _ichannels: 0,
@@ -79,7 +79,7 @@ impl Driver for LocalBufferDriver {
         let (_, dsp_func) = &vm.prog.global_fn_table[dsp_i];
         self.ochannels = dsp_func.nret as u64;
         self.localbuffer = Vec::with_capacity(dsp_func.nret * self.times);
-        self.samplerate = sample_rate.unwrap_or(SampleRate(48000));
+        self.samplerate = sample_rate.unwrap_or(SampleRate::from(48000));
 
         self.vmdata = Some(RuntimeData::new(vm, ctx.sys_plugins));
 
@@ -108,8 +108,8 @@ impl Driver for LocalBufferDriver {
         false
     }
 
-    fn get_samplerate(&self) -> SampleRate {
-        self.samplerate
+    fn get_samplerate(&self) -> u32 {
+        self.samplerate.get()
     }
 
     fn get_current_sample(&self) -> Time {

--- a/mimium-audiodriver/src/runtime_fn.rs
+++ b/mimium-audiodriver/src/runtime_fn.rs
@@ -2,7 +2,7 @@ use std::{
     cell::RefCell,
     rc::Rc,
     sync::{
-        atomic::{AtomicU64, Ordering},
+        atomic::{AtomicU32, AtomicU64, Ordering},
         Arc,
     },
 };
@@ -23,6 +23,18 @@ pub fn gen_getnowfn(count: Arc<AtomicU64>) -> ExtClsInfo {
     }));
     (
         "_mimium_getnow".to_symbol(),
+        func,
+        function!(vec![], numeric!()),
+    )
+}
+pub fn gen_getsampleratefn(samplerate: Arc<AtomicU32>) -> ExtClsInfo {
+    let func = Rc::new(RefCell::new(move |machine: &mut Machine| {
+        let count = samplerate.load(Ordering::Relaxed) as f64;
+        machine.set_stack(0, Machine::to_value(count));
+        1
+    }));
+    (
+        "_mimium_getsamplerate".to_symbol(),
         func,
         function!(vec![], numeric!()),
     )

--- a/mimium-audiodriver/tests/getnow.rs
+++ b/mimium-audiodriver/tests/getnow.rs
@@ -48,7 +48,7 @@ fn getnow_test() {
     let p: Box<dyn Plugin> = Box::new(driver.get_as_plugin());
     let mut ctx = ExecContext::new([p].into_iter(), None);
     ctx.prepare_machine_with_bytecode(prog);
-    driver.init(ctx, Some(SampleRate(48000)));
+    driver.init(ctx, Some(SampleRate::from(48000)));
     driver.play();
 
     let res = driver.get_generated_samples();

--- a/mimium-cli/src/main.rs
+++ b/mimium-cli/src/main.rs
@@ -232,7 +232,7 @@ fn run_file(
                 eprintln!("Press Enter to exit");
                 let _size = stdin().read_line(&mut dummy).expect("stdin read error.");
             }));
-            driver.init(ctx, Some(SampleRate(48000)));
+            driver.init(ctx, Some(SampleRate::from(48000)));
             driver.play();
             mainloop()
         }

--- a/mimium-lang/src/ast.rs
+++ b/mimium-lang/src/ast.rs
@@ -14,6 +14,7 @@ pub enum Literal {
     Float(Symbol),
     SelfLit,
     Now,
+    SampleRate,
     PlaceHolder,
 }
 
@@ -64,6 +65,7 @@ impl fmt::Display for Literal {
             Literal::Int(n) => write!(f, "(int {})", n),
             Literal::String(s) => write!(f, "\"{}\"", s),
             Literal::Now => write!(f, "now"),
+            Literal::SampleRate => write!(f, "samplerate"),
             Literal::SelfLit => write!(f, "self"),
             Literal::PlaceHolder => write!(f, "_"),
         }

--- a/mimium-lang/src/ast_interpreter.rs
+++ b/mimium-lang/src/ast_interpreter.rs
@@ -116,6 +116,9 @@ fn eval_literal(e: &ast::Literal) -> Value {
         ast::Literal::Now => {
             panic!("now literal should not be shown in evaluation stage.")
         }
+        ast::Literal::SampleRate => {
+            panic!("samplerate literal should not be shown in evaluation stage.")
+        }
         ast::Literal::PlaceHolder => {
             panic!("_ literal should not be shown in evaluation stage.")
         }

--- a/mimium-lang/src/compiler/mirgen.rs
+++ b/mimium-lang/src/compiler/mirgen.rs
@@ -312,6 +312,12 @@ impl Context {
                 let getnow = Arc::new(Value::ExtFunction("_mimium_getnow".to_symbol(), fntype));
                 self.push_inst(Instruction::CallCls(getnow, vec![], ftype))
             }
+            Literal::SampleRate => {
+                let ftype = numeric!();
+                let fntype = function!(vec![], ftype);
+                let samplerate = Arc::new(Value::ExtFunction("_mimium_getsamplerate".to_symbol(), fntype));
+                self.push_inst(Instruction::CallCls(samplerate, vec![], ftype))
+            }
             Literal::SelfLit | Literal::PlaceHolder => unreachable!(),
         };
         Ok(v)

--- a/mimium-lang/src/compiler/parser.rs
+++ b/mimium-lang/src/compiler/parser.rs
@@ -66,6 +66,7 @@ fn literals_parser() -> impl Parser<Token, ExprNodeId, Error = Simple<Token>> + 
         Token::Str(s) => Literal::String(s.to_symbol()),
         Token::SelfLit => Literal::SelfLit,
         Token::Now => Literal::Now,
+        Token::SampleRate => Literal::SampleRate,
         Token::PlaceHolder => Literal::PlaceHolder,
     }
     .map_with_span(|e, s| Expr::Literal(e).into_id(s))

--- a/mimium-lang/src/compiler/parser/lexer.rs
+++ b/mimium-lang/src/compiler/parser/lexer.rs
@@ -74,6 +74,7 @@ pub fn lexer() -> impl Parser<char, Vec<(Token, Span)>, Error = Simple<char>> {
         "macro" => Token::Macro,
         "self" => Token::SelfLit,
         "now" => Token::Now,
+        "samplerate" => Token::SampleRate,
         "let" => Token::Let,
         "letrec" => Token::LetRec,
         "if" => Token::If,

--- a/mimium-lang/src/compiler/parser/token.rs
+++ b/mimium-lang/src/compiler/parser/token.rs
@@ -52,7 +52,7 @@ pub enum Token {
     Op(Op),
     SelfLit,
     Now,
-
+    SampleRate,
     Comma,
     Dot,
 
@@ -157,6 +157,7 @@ impl fmt::Display for Token {
             Token::Op(x) => write!(f, "{}", x),
             Token::SelfLit => write!(f, "self"),
             Token::Now => write!(f, "now"),
+            Token::SampleRate => write!(f, "samplerate"),
             Token::Comma => write!(f, ","),
             Token::Dot => write!(f, "."),
             Token::Colon => write!(f, ":"),

--- a/mimium-lang/src/compiler/typing.rs
+++ b/mimium-lang/src/compiler/typing.rs
@@ -429,10 +429,9 @@ impl InferContext {
     }
     pub(crate) fn infer_type_literal(e: &Literal) -> Result<TypeNodeId, Error> {
         let pt = match e {
-            Literal::Float(_s) => PType::Numeric,
+            Literal::Float(_) | Literal::Now | Literal::SampleRate => PType::Numeric,
             Literal::Int(_s) => PType::Int,
             Literal::String(_s) => PType::String,
-            Literal::Now => PType::Numeric,
             Literal::SelfLit => panic!("\"self\" should not be shown at type inference stage"),
             Literal::PlaceHolder => panic!("\"_\" should not be shown at type inference stage"),
         };

--- a/mimium-lang/src/runtime/vm/builtin.rs
+++ b/mimium-lang/src/runtime/vm/builtin.rs
@@ -21,17 +21,17 @@ fn probelnf(machine: &mut Machine) -> ReturnCode {
     1
 }
 fn min(machine: &mut Machine) -> ReturnCode {
-    let lhs = machine.get_stack(0);
-    let rhs = machine.get_stack(1);
-
-    machine.set_stack(0, super::Machine::to_value(lhs.min(rhs)));
+    let lhs = super::Machine::get_as::<f64>(machine.get_stack(0));
+    let rhs = super::Machine::get_as::<f64>(machine.get_stack(1));
+    let res = lhs.min(rhs);
+    machine.set_stack(0, super::Machine::to_value(res));
     1
 }
 fn max(machine: &mut Machine) -> ReturnCode {
-    let lhs = machine.get_stack(0);
-    let rhs = machine.get_stack(1);
-
-    machine.set_stack(0, super::Machine::to_value(lhs.max(rhs)));
+    let lhs = super::Machine::get_as::<f64>(machine.get_stack(0));
+    let rhs = super::Machine::get_as::<f64>(machine.get_stack(1));
+    let res = lhs.max(rhs);
+    machine.set_stack(0, super::Machine::to_value(res));
     1
 }
 


### PR DESCRIPTION
This PR adds new literal `samplerate` that is the alias to the runtime function call `_mimium_getsamplerate()` like `now`.

