### PR TITLE
use 24bit integer for push/popstatepos insruction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1140,6 +1140,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "intx"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f38a50a899dc47a6d0ed5508e7f601a2e34c3a85303514b5d137f3c10a0c75"
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1388,6 +1394,7 @@ dependencies = [
  "chumsky",
  "colog",
  "half",
+ "intx",
  "itertools 0.13.0",
  "log",
  "mimalloc",

--- a/mimium-lang/Cargo.toml
+++ b/mimium-lang/Cargo.toml
@@ -23,3 +23,4 @@ colog = "1.3.0"
 half = "2.4.1"
 itertools = "0.13.0"
 mimalloc = { version = "0.1.43", optional = true }
+intx = "0.1.0"

--- a/mimium-lang/src/runtime/vm/bytecode.rs
+++ b/mimium-lang/src/runtime/vm/bytecode.rs
@@ -4,7 +4,8 @@ pub type Reg = u8; // register position
 pub type ConstPos = u16;
 pub type GlobalPos = u8;
 pub type Offset = i16;
-
+//24bit unsigned integer for shiftsate
+pub type StateOffset = intx::U24;
 /// Instructions for bytecode. Currently, each instructon has the 64 bit size(Tag, up to 3 bytes arguments.)
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Instruction {
@@ -41,7 +42,8 @@ pub enum Instruction {
     /// Call internal state over time, destination,source
     GetState(Reg, TypeSize),
     SetState(Reg, TypeSize),
-    ShiftStatePos(Offset),
+    PushStatePos(StateOffset),
+    PopStatePos(StateOffset),
 
     /// Return from current function without return value.
     Return0,
@@ -106,7 +108,9 @@ impl std::fmt::Display for Instruction {
             Instruction::Jmp(dst) => write!(f, "{:<10} {}", "jmp", dst),
             Instruction::GetState(dst, size) => write!(f, "{:<10} {} {}", "getstate", dst, size),
             Instruction::SetState(src, size) => write!(f, "{:<10} {} {}", "setstate", src, size),
-            Instruction::ShiftStatePos(v) => write!(f, "{:<10} {}", "shiftsttpos", v),
+            Instruction::PushStatePos(v) => write!(f, "{:<10} {}", "pushsttpos", v),
+            Instruction::PopStatePos(v) => write!(f, "{:<10} {}", "popsttpos", v),
+
             Instruction::Move(dst, src) => write!(f, "{:<10} {} {}", "mov", dst, src),
             Instruction::MoveConst(dst, num) => write!(f, "{:<10} {} {}", "movc", dst, num),
             Instruction::MoveImmF(dst,v)=> write!(f, "{:<10} {} {}", "movimmF", dst, v),


### PR DESCRIPTION
related to #101.

Because the internal representation of `u24` in `uX` crate was u32, instead I used `intx` crate. (Maybe I will implement u24 by myself later if there is some problem because the intx looks not maintained actively)

