### PR TITLE
`include` can find stdlib file from a default search path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1102,6 +1102,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "homedir"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bdbbd5bc8c5749697ccaa352fa45aff8730cf21c68029c0eef1ffed7c3d6ba2"
+dependencies = [
+ "cfg-if",
+ "nix",
+ "widestring",
+ "windows 0.57.0",
+]
+
+[[package]]
 name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1394,6 +1406,7 @@ dependencies = [
  "chumsky",
  "colog",
  "half",
+ "homedir",
  "intx",
  "itertools 0.13.0",
  "log",
@@ -1506,6 +1519,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
 dependencies = [
  "jni-sys",
+]
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.6.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
 ]
 
 [[package]]
@@ -2690,6 +2715,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "widestring"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7219d36b6eac893fa81e84ebe06485e7dcbb616177469b142df14f1f4deb1311"
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2741,6 +2772,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
+dependencies = [
+ "windows-core 0.57.0",
+ "windows-targets 0.52.5",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2756,8 +2797,20 @@ version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4698e52ed2d08f8658ab0c39512a7c00ee5fe2688c65f8c0a4f06750d729f2a6"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.56.0",
+ "windows-interface 0.56.0",
+ "windows-result",
+ "windows-targets 0.52.5",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
+dependencies = [
+ "windows-implement 0.57.0",
+ "windows-interface 0.57.0",
  "windows-result",
  "windows-targets 0.52.5",
 ]
@@ -2774,10 +2827,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-implement"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-interface"
 version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08990546bf4edef8f431fa6326e032865f27138718c587dc21bc0265bbcb57cc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -8,10 +8,19 @@ cargo-dist-version = "0.25.1"
 # CI backends to support
 ci = "github"
 # The installers to generate for each app
-installers = []
+installers = ["shell", "msi", "powershell"]
 # Target platforms to build apps for (Rust target-triple syntax)
-targets = ["aarch64-apple-darwin", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
+targets = [
+    "aarch64-apple-darwin",
+    "x86_64-apple-darwin",
+    "x86_64-unknown-linux-gnu",
+    "x86_64-pc-windows-msvc",
+]
 
+include = ["./mimium-cli/lib/", ".Readme.md", "./mimium_logo_slant.svg"]
+
+unix-archive = ".zip"
+windows-archive = ".zip"
 
 [dist.dependencies.apt]
 libasound2-dev = "*"

--- a/mimium-cli/examples/sinewave.mmm
+++ b/mimium-cli/examples/sinewave.mmm
@@ -1,4 +1,4 @@
-include("../../mimium-lang/lib/osc.mmm")
+include("osc.mmm")
 
 fn dsp(){
   let r = sinwave(440.0,0.0)*0.2

--- a/mimium-lang/Cargo.toml
+++ b/mimium-lang/Cargo.toml
@@ -24,6 +24,7 @@ half = "2.4.1"
 itertools = "0.13.0"
 mimalloc = { version = "0.1.43", optional = true }
 intx = "0.1.0"
+homedir = "0.3.4"
 
 [lints.clippy]
 useless_format = "allow"

--- a/mimium-lang/src/compiler/parser/resolve_include.rs
+++ b/mimium-lang/src/compiler/parser/resolve_include.rs
@@ -19,15 +19,10 @@ pub(super) fn resolve_include(
         span: span.clone(),
         path: mmm_filepath.to_symbol(),
     };
-    let abspath = fileloader::get_canonical_path(mmm_filepath, target_path)
+    let res = fileloader::load_mmmlibfile(mmm_filepath, target_path)
         .map_err(|e| make_vec_error(e, loc.clone()));
-    match abspath {
-        Ok(abspath) => {
-            match fileloader::load(abspath.to_str().unwrap()).map_err(|e| make_vec_error(e, loc)) {
-                Ok(content) => parse(&content, Some(abspath)),
-                Err(errs) => (Expr::Error.into_id_without_span(), errs),
-            }
-        }
-        Err(errs) => (Expr::Error.into_id_without_span(), errs),
+    match res {
+        Ok((content, path)) => parse(&content, Some(path)),
+        Err(err) => (Expr::Error.into_id(loc), err),
     }
 }


### PR DESCRIPTION
Currently, the path for the `include` must be a relative path from the file.

This PR adds a functionality so that the compiler can find the file from `${HOME}/.mimium/lib`.

I'm gonna try to include files in `mimium-lang/lib` when packaging with cargo-dist in the next release.