### PR TITLE
Fix incorrect type inference

### DIFF
--- a/mimium-cli/examples/multiosc.mmm
+++ b/mimium-cli/examples/multiosc.mmm
@@ -6,10 +6,10 @@ fn osc(freq){
 fn amosc(freq,rate){
   osc(freq + osc(rate)*4000.0)
 }
-fn replicate(n,gen:()->(float,float)->float){
+fn replicate(n,gen){
     if (n>0.0){
         let c = replicate(n - 1.0,gen)
-        let g = gen()
+        let g =  gen()
         |x,rate| g(x,rate) + c(x+100.0,rate+0.1)
     }else{
         |x,rate|  0

--- a/mimium-lang/src/compiler/mirgen.rs
+++ b/mimium-lang/src/compiler/mirgen.rs
@@ -635,7 +635,7 @@ impl Context {
                 if let Ok(tid) = TypedId::try_from(pat.clone()) {
                     self.fn_label = Some(tid.id);
                     log::trace!(
-                        "{}",
+                        "mirgen let {}",
                         self.fn_label.map_or("".to_string(), |s| s.to_string())
                     )
                 };

--- a/mimium-lang/src/types.rs
+++ b/mimium-lang/src/types.rs
@@ -45,7 +45,6 @@ pub enum Type {
     Code(TypeNodeId),
     Intermediate(Rc<RefCell<TypeVar>>),
     TypeScheme(u64),
-    // Instantiated(u64),
     /// Failure type: it is bottom type that can be unified to any type and return bottom type.
     Failure,
     Unknown,
@@ -230,9 +229,6 @@ impl fmt::Display for Type {
             Type::TypeScheme(id) => {
                 write!(f, "g({id})")
             }
-            // Type::Instantiated(id) => {
-            //     write!(f, "'{id}")
-            // }
             Type::Failure => write!(f, "!"),
             Type::Unknown => write!(f, "unknown"),
         }

--- a/mimium-lang/src/types.rs
+++ b/mimium-lang/src/types.rs
@@ -45,7 +45,7 @@ pub enum Type {
     Code(TypeNodeId),
     Intermediate(Rc<RefCell<TypeVar>>),
     TypeScheme(u64),
-    Instantiated(u64),
+    // Instantiated(u64),
     /// Failure type: it is bottom type that can be unified to any type and return bottom type.
     Failure,
     Unknown,
@@ -230,9 +230,9 @@ impl fmt::Display for Type {
             Type::TypeScheme(id) => {
                 write!(f, "g({id})")
             }
-            Type::Instantiated(id) => {
-                write!(f, "'{id}")
-            }
+            // Type::Instantiated(id) => {
+            //     write!(f, "'{id}")
+            // }
             Type::Failure => write!(f, "!"),
             Type::Unknown => write!(f, "unknown"),
         }

--- a/mimium-test/tests/intergration_test.rs
+++ b/mimium-test/tests/intergration_test.rs
@@ -109,7 +109,7 @@ fn primitive_log() {
     let res = run_file_test_mono("primitive_log.mmm", 1).unwrap();
     let ans = [2.0f64.log10()];
     let r = (res[0] - ans[0]).abs() < f64::EPSILON;
-    assert!(r);
+    assert!(r,"res:{} expected: {}",res[0],ans[0]);
 }
 
 #[test]

--- a/mimium-test/tests/intergration_test.rs
+++ b/mimium-test/tests/intergration_test.rs
@@ -356,5 +356,13 @@ fn if_state() {
 fn many_errors() {
     let res = run_error_test("many_errors.mmm", false);
     //todo! check error types
-    assert_eq!(res.len(), 6);
+    assert_eq!(res.len(), 7);
+}
+#[test]
+
+fn hof_typefail() {
+    //check false positive
+    let res = run_error_test("hof_typefail.mmm", false);
+    //todo! check error types
+    assert_eq!(res.len(), 1);
 }

--- a/mimium-test/tests/intergration_test.rs
+++ b/mimium-test/tests/intergration_test.rs
@@ -272,6 +272,24 @@ fn hof_state() {
 }
 
 #[test]
+fn hof_infer() {
+    let res = run_file_test_mono("hof_infer.mmm", 10).unwrap();
+    let ans = vec![
+        0.0,
+        0.6000000000000001,
+        1.2000000000000002,
+        1.8000000000000003,
+        2.4000000000000004,
+        3.0,
+        3.5999999999999996,
+        4.199999999999999,
+        4.8,
+        5.3999999999999995,
+    ];
+    assert_eq!(res, ans);
+}
+
+#[test]
 fn simple_stereo() {
     let res = run_file_test_stereo("simple_stereo.mmm", 3).unwrap();
     let ans = vec![1.0, 2.0, 1.0, 2.0, 1.0, 2.0];

--- a/mimium-test/tests/mmm/hof_infer.mmm
+++ b/mimium-test/tests/mmm/hof_infer.mmm
@@ -1,0 +1,18 @@
+//this is exactly same as hof_state.mmm but now works without explicit type annotation.
+fn counter(inc){
+    self+inc
+}
+
+fn replicate(n,gen){
+    if (n>0.0){
+        let c = replicate(n - 1.0,gen)
+        let g = gen()
+        |x| {g(x) * n + c(x)}
+    }else{
+        |x| { 0.0 }
+    }
+}
+let mycounter = replicate(3.0,| |counter);
+fn dsp(){
+    mycounter(0.1)
+}

--- a/mimium-test/tests/mmm/hof_typefail.mmm
+++ b/mimium-test/tests/mmm/hof_typefail.mmm
@@ -1,0 +1,11 @@
+let doublethunk = | | {| | 1.0} 
+
+fn hof_ident(f:()->float)-> ()->float {
+    f
+}
+
+let f = hof_ident(doublethunk) //this should be an error
+
+fn dsp()->float{
+ f()
+}


### PR DESCRIPTION
This PR fixes the incorrect type unification in function type.

Previously, the incorrect higher-order funtion like the code below  was not treated as an error.

```rust
let doublethunk = | | {| | 1.0} 

fn hof_ident(f:()->float)-> ()->float {
    f
}

let f = hof_ident(doublethunk) //this should be an error

fn dsp()->float{
 f()
}
```

This PR also fixes incorrect type definition of primitive log function.