### PR TITLE
fix crash when accessing self keyword in nested block scope

### DIFF
--- a/crates/lib/mimium-lang/src/runtime/vm.rs
+++ b/crates/lib/mimium-lang/src/runtime/vm.rs
@@ -771,6 +771,16 @@ impl Machine {
                 }
                 Instruction::Call(func, nargs, nret_req) => {
                     let pos_of_f = Self::get_as::<usize>(self.get_stack(func as i64));
+                    let func_proto = self.get_fnproto(pos_of_f);
+                    
+                    let required_state_size = func_proto.state_skeleton.total_size() as usize;
+                    if required_state_size > 0 && self.states_stack.0.is_empty() {
+                        let needs_resize = self.global_states.rawdata.len() < required_state_size;
+                        if needs_resize {
+                            self.global_states.resize(required_state_size);
+                        }
+                    }
+                    
                     self.call_function(func, nargs, nret_req, move |machine| {
                         machine.execute(pos_of_f, None)
                     });


### PR DESCRIPTION
**Description**

This issue occurred when I tried to run `example/0b5vr.mmm` and encountered a crash with `an invalid memory reference` error. After investigating, I found that the problem potentially stems from functions using the `self` keyword being called from within nested block scopes (in this case, from the `integ` function in `example/0b5vr.mmm`). This happened because the VM wasn't properly allocating global state storage for functions requiring state in these contexts.

**Solution:**
Added state size validation in `Instruction::Call` to ensure the global state buffer is adequately sized before function execution.

I also added a unit test `test_self_nested_block_allocation` to verify the fix (though I'm not sure I implemented it correctly, as bytecodes are new to me 😵).