### PR TITLE
fix stale function index when program updates

### DIFF
--- a/crates/lib/plugins/mimium-audiodriver/src/backends/cpal.rs
+++ b/crates/lib/plugins/mimium-audiodriver/src/backends/cpal.rs
@@ -90,7 +90,7 @@ impl NativeAudioData {
     }
     pub fn process(&mut self, dst: &mut [f32], h_ochannels: usize) {
         if let Ok(swap) = self.swap_channel.try_recv() {
-            self.vmdata.vm = self.vmdata.vm.new_resume(swap);
+            self.vmdata = self.vmdata.new_resume(swap);
         }
         // let len = dst.len().min(self.localbuffer.len());
         let len = dst.len();

--- a/crates/lib/plugins/mimium-audiodriver/src/driver.rs
+++ b/crates/lib/plugins/mimium-audiodriver/src/driver.rs
@@ -119,7 +119,7 @@ impl RuntimeData {
         if let Some(IoChannelInfo { input, .. }) = self.vm.prog.iochannels {
             self.vm.set_stack_range(0, &vec![0u64; input as usize]);
         }
-        let dsp_i = self.vm.prog.get_fun_index("dsp").unwrap_or(0);
+        let dsp_i = new_prog.get_fun_index("dsp").unwrap_or(0);
         Self {
             vm: self.vm.new_resume(new_prog),
             sys_plugins: self.sys_plugins.clone(),


### PR DESCRIPTION
**Description**

fixes an indexing error ( `dsp_i` ) that occurs when program is running (more details please see #174), ensuring all tests passed.
 




