### PR TITLE
docs: fix mimium-cli run instructions in Development.md

### DIFF
--- a/Development.md
+++ b/Development.md
@@ -63,7 +63,7 @@ Open `mimium-rs.code-workspace` with VSCode. The workspace contains recommended 
 
 ## How to Run & Debug
 
-You can run built `mimium-cli` by running `cargo run -- targetfile.mmm`. Note that you need to be in `mimium-cli` directory.
+You can run built `mimium-cli` by running `cargo run --bin mimium-cli -- path/to/file.mmm`. Note that you need to be in `crates/bin/mimium-bintools` directory.
 
 Note that the binary with debug configuration is slow, you may hear the glitch noise (because of audio driver underrun). You should try with release build when you are trying to check audio with `--release` option.
 


### PR DESCRIPTION
### Summary

This PR fixes the `Development.md` instructions for running `mimium-cli`.

The previous command:

```bash
cargo run -- targetfile.mmm
```

in the `mimium-cli` directory no longer matches the current workspace layout.

This PR updates the documentation to use:

```bash
cargo run --bin mimium-cli -- path/to/file.mmm
```

from `crates/bin/mimium-bintools`, which reflects the current package structure.
